### PR TITLE
3 missing test cases for failures

### DIFF
--- a/abstractions.go
+++ b/abstractions.go
@@ -109,7 +109,7 @@ type Sortable[V Value] interface {
 }
 
 // This interface defines the methods supported by all binding associations.
-// It binds a readonly key with an setable value.
+// It binds a readonly key with a setable value.
 type Binding[K Key, V Value] interface {
 	GetKey() K
 	GetValue() V

--- a/array.go
+++ b/array.go
@@ -91,7 +91,13 @@ func (v Array[V]) GetIndex(value V) int {
 func (v Array[V]) GoIndex(index int) int {
 	var length = len(v)
 	switch {
-	case index < -length || index == 0 || index > length:
+	case length == 0:
+		// The array is empty.
+		panic("Cannot index an empty array.")
+	case index == 0:
+		// Zero is not an ordinal.
+		panic("Indices must be positive or negative ordinals, not zero.")
+	case index < -length || index > length:
 		// The index is outside the bounds of the specified range.
 		panic(fmt.Sprintf(
 			"The specified index is outside the allowed ranges [-%v..-1] and [1..%v]: %v",
@@ -105,8 +111,8 @@ func (v Array[V]) GoIndex(index int) int {
 		// Convert a positive index.
 		return index - 1
 	default:
-		// This should never happen so time to panic...
-		panic(fmt.Sprintf("Compiler problem, unexpected index value: %v", index))
+		// This should never happen so time to...
+		panic(fmt.Sprintf("Go compiler problem, unexpected index value: %v", index))
 	}
 }
 

--- a/array_test.go
+++ b/array_test.go
@@ -16,7 +16,7 @@ import (
 	tes "testing"
 )
 
-func TestEmptyArrays(t *tes.T) {
+func TestEmptyArray(t *tes.T) {
 	var array = col.Array[string]([]string{})
 	ass.True(t, array.IsEmpty())
 	ass.Equal(t, 0, array.GetSize())
@@ -28,9 +28,25 @@ func TestEmptyArrays(t *tes.T) {
 	ass.False(t, iterator.HasPrevious())
 	iterator.ToStart()
 	iterator.ToEnd()
+	defer func() {
+		if e := recover(); e != nil {
+			ass.Equal(t, "Cannot index an empty array.", e)
+		}
+	}()
+	array.GoIndex(0) // This should panic.
 }
 
-func TestArraysWithStrings(t *tes.T) {
+func TestArrayIndexOfZero(t *tes.T) {
+	var array = col.Array[int]([]int{1, 2, 3})
+	defer func() {
+		if e := recover(); e != nil {
+			ass.Equal(t, "Indices must be positive or negative ordinals, not zero.", e)
+		}
+	}()
+	array.GoIndex(0) // This should panic.
+}
+
+func TestArrayWithStrings(t *tes.T) {
 	var array = col.Array[string]([]string{"foo", "bar", "baz"})
 	var foobar = col.Array[string]([]string{"foo", "bar"})
 	ass.False(t, array.IsEmpty())
@@ -49,4 +65,24 @@ func TestArraysWithStrings(t *tes.T) {
 	ass.Equal(t, []string{"foo", "bax", "baz"}, array.AsArray())
 	array.SetValues(2, foobar)
 	ass.Equal(t, []string{"foo", "foo", "bar"}, array.AsArray())
+	defer func() {
+		if e := recover(); e != nil {
+			ass.Equal(t, "The specified index is outside the allowed ranges [-3..-1] and [1..3]: 4", e)
+		}
+	}()
+	array.GoIndex(4) // This should panic.
+}
+
+func TestArrayWithIntegers(t *tes.T) {
+	var array = col.Array[int]([]int{1, 2, 3})
+	for index, value := range array {
+		ass.Equal(t, index, array.GoIndex(value))
+		ass.Equal(t, index, array.GoIndex(value-4))
+	}
+	defer func() {
+		if e := recover(); e != nil {
+			ass.Equal(t, "The specified index is outside the allowed ranges [-3..-1] and [1..3]: -4", e)
+		}
+	}()
+	array.GoIndex(-4) // This should panic.
 }

--- a/array_test.go
+++ b/array_test.go
@@ -31,6 +31,8 @@ func TestEmptyArray(t *tes.T) {
 	defer func() {
 		if e := recover(); e != nil {
 			ass.Equal(t, "Cannot index an empty array.", e)
+		} else {
+			ass.Fail(t, "Test should result in recovered panic.")
 		}
 	}()
 	array.GoIndex(0) // This should panic.
@@ -41,6 +43,8 @@ func TestArrayIndexOfZero(t *tes.T) {
 	defer func() {
 		if e := recover(); e != nil {
 			ass.Equal(t, "Indices must be positive or negative ordinals, not zero.", e)
+		} else {
+			ass.Fail(t, "Test should result in recovered panic.")
 		}
 	}()
 	array.GoIndex(0) // This should panic.
@@ -68,6 +72,8 @@ func TestArrayWithStrings(t *tes.T) {
 	defer func() {
 		if e := recover(); e != nil {
 			ass.Equal(t, "The specified index is outside the allowed ranges [-3..-1] and [1..3]: 4", e)
+		} else {
+			ass.Fail(t, "Test should result in recovered panic.")
 		}
 	}()
 	array.GoIndex(4) // This should panic.
@@ -82,6 +88,8 @@ func TestArrayWithIntegers(t *tes.T) {
 	defer func() {
 		if e := recover(); e != nil {
 			ass.Equal(t, "The specified index is outside the allowed ranges [-3..-1] and [1..3]: -4", e)
+		} else {
+			ass.Fail(t, "Test should result in recovered panic.")
 		}
 	}()
 	array.GoIndex(-4) // This should panic.

--- a/collator.go
+++ b/collator.go
@@ -396,16 +396,22 @@ func (v *collator) rankMaps(first ref.Value, second ref.Value) int {
 
 	// Iterate through the smallest map.
 	for i := 0; i < firstSize; i++ {
+		v.depth++
+		if v.depth > maximumRecursion {
+			panic(fmt.Sprintf("The maximum recursion depth was exceeded: %v", maximumRecursion))
+		}
 		// Rank the two keys.
 		var firstKey = firstKeys[i]
 		var secondKey = secondKeys[i]
 		var keyRank = v.rankValues(firstKey, secondKey)
 		if keyRank < 0 {
 			// The key in the first map comes before its matching key.
+			v.depth--
 			return -1
 		}
 		if keyRank > 0 {
 			// The key in the first map comes after its matching key.
+			v.depth--
 			return 1
 		}
 
@@ -415,12 +421,15 @@ func (v *collator) rankMaps(first ref.Value, second ref.Value) int {
 		var valueRank = v.rankValues(firstValue, secondValue)
 		if valueRank < 0 {
 			// The value in the first map comes before its matching value.
+			v.depth--
 			return -1
 		}
 		if valueRank > 0 {
 			// The value in the first map comes after its matching value.
+			v.depth--
 			return 1
 		}
+		v.depth--
 	}
 
 	// The maps contain the same initial associations.

--- a/collator_test.go
+++ b/collator_test.go
@@ -155,14 +155,11 @@ func TestComparison(t *tes.T) {
 	ass.True(t, col.CompareValues(m2, m2))
 }
 
-type invalid struct {
-}
-
 func TestCompareInvalidTypes(t *tes.T) {
-	var s invalid
+	var s struct{}
 	defer func() {
 		if e := recover(); e != nil {
-			ass.Equal(t, "Attempted to compare:\n\tfirst: {}\n\ttype: collections_test.invalid\n\tkind: struct\nand\n\tsecond: {}\n\ttype: collections_test.invalid\n\tkind: struct\n", e)
+			ass.Equal(t, "Attempted to compare:\n\tfirst: {}\n\ttype: struct {}\n\tkind: struct\nand\n\tsecond: {}\n\ttype: struct {}\n\tkind: struct\n", e)
 		}
 	}()
 	col.CompareValues(s, s) // This should panic.
@@ -374,10 +371,10 @@ func TestRanking(t *tes.T) {
 }
 
 func TestRankInvalidTypes(t *tes.T) {
-	var s invalid
+	var s struct{}
 	defer func() {
 		if e := recover(); e != nil {
-			ass.Equal(t, "Attempted to rank:\n\tfirst: {}\n\ttype: collections_test.invalid\n\tkind: struct\nand\n\tsecond: {}\n\ttype: collections_test.invalid\n\tkind: struct\n", e)
+			ass.Equal(t, "Attempted to rank:\n\tfirst: {}\n\ttype: struct {}\n\tkind: struct\nand\n\tsecond: {}\n\ttype: struct {}\n\tkind: struct\n", e)
 		}
 	}()
 	col.RankValues(s, s) // This should panic.

--- a/collator_test.go
+++ b/collator_test.go
@@ -155,6 +155,41 @@ func TestComparison(t *tes.T) {
 	ass.True(t, col.CompareValues(m2, m2))
 }
 
+type invalid struct {
+}
+
+func TestCompareInvalidTypes(t *tes.T) {
+	var s invalid
+	defer func() {
+		if e := recover(); e != nil {
+			ass.Equal(t, "Attempted to compare:\n\tfirst: {}\n\ttype: collections_test.invalid\n\tkind: struct\nand\n\tsecond: {}\n\ttype: collections_test.invalid\n\tkind: struct\n", e)
+		}
+	}()
+	col.CompareValues(s, s) // This should panic.
+}
+
+func TestCompareRecursiveArrays(t *tes.T) {
+	var array = col.Array[any]([]any{0})
+	array.SetValue(1, array) // Now it is recursive.
+	defer func() {
+		if e := recover(); e != nil {
+			ass.Equal(t, "The maximum recursion depth was exceeded: 100", e)
+		}
+	}()
+	col.CompareValues(array, array) // This should panic.
+}
+
+func TestCompareRecursiveMaps(t *tes.T) {
+	var m = col.Map[string, any](map[string]any{"first":1})
+	m.SetValue("first", m) // Now it is recursive.
+	defer func() {
+		if e := recover(); e != nil {
+			ass.Equal(t, "The maximum recursion depth was exceeded: 100", e)
+		}
+	}()
+	col.CompareValues(m, m) // This should panic.
+}
+
 func TestRanking(t *tes.T) {
 	// Nil
 	var ShouldBeNil any
@@ -336,4 +371,36 @@ func TestRanking(t *tes.T) {
 	ass.Equal(t, 0, col.RankValues(m4, m4))
 	ass.Equal(t, 1, col.RankValues(m1, m4))
 	ass.Equal(t, 0, col.RankValues(m1, m1))
+}
+
+func TestRankInvalidTypes(t *tes.T) {
+	var s invalid
+	defer func() {
+		if e := recover(); e != nil {
+			ass.Equal(t, "Attempted to rank:\n\tfirst: {}\n\ttype: collections_test.invalid\n\tkind: struct\nand\n\tsecond: {}\n\ttype: collections_test.invalid\n\tkind: struct\n", e)
+		}
+	}()
+	col.RankValues(s, s) // This should panic.
+}
+
+func TestRankRecursiveArrays(t *tes.T) {
+	var array = col.Array[any]([]any{0})
+	array.SetValue(1, array) // Now it is recursive.
+	defer func() {
+		if e := recover(); e != nil {
+			ass.Equal(t, "The maximum recursion depth was exceeded: 100", e)
+		}
+	}()
+	col.RankValues(array, array) // This should panic.
+}
+
+func TestRankRecursiveMaps(t *tes.T) {
+	var m = col.Map[string, any](map[string]any{"first":1})
+	m.SetValue("first", m) // Now it is recursive.
+	defer func() {
+		if e := recover(); e != nil {
+			ass.Equal(t, "The maximum recursion depth was exceeded: 100", e)
+		}
+	}()
+	col.RankValues(m, m) // This should panic.
 }

--- a/collator_test.go
+++ b/collator_test.go
@@ -160,6 +160,8 @@ func TestCompareInvalidTypes(t *tes.T) {
 	defer func() {
 		if e := recover(); e != nil {
 			ass.Equal(t, "Attempted to compare:\n\tfirst: {}\n\ttype: struct {}\n\tkind: struct\nand\n\tsecond: {}\n\ttype: struct {}\n\tkind: struct\n", e)
+		} else {
+			ass.Fail(t, "Test should result in recovered panic.")
 		}
 	}()
 	col.CompareValues(s, s) // This should panic.
@@ -171,6 +173,8 @@ func TestCompareRecursiveArrays(t *tes.T) {
 	defer func() {
 		if e := recover(); e != nil {
 			ass.Equal(t, "The maximum recursion depth was exceeded: 100", e)
+		} else {
+			ass.Fail(t, "Test should result in recovered panic.")
 		}
 	}()
 	col.CompareValues(array, array) // This should panic.
@@ -182,6 +186,8 @@ func TestCompareRecursiveMaps(t *tes.T) {
 	defer func() {
 		if e := recover(); e != nil {
 			ass.Equal(t, "The maximum recursion depth was exceeded: 100", e)
+		} else {
+			ass.Fail(t, "Test should result in recovered panic.")
 		}
 	}()
 	col.CompareValues(m, m) // This should panic.
@@ -375,6 +381,8 @@ func TestRankInvalidTypes(t *tes.T) {
 	defer func() {
 		if e := recover(); e != nil {
 			ass.Equal(t, "Attempted to rank:\n\tfirst: {}\n\ttype: struct {}\n\tkind: struct\nand\n\tsecond: {}\n\ttype: struct {}\n\tkind: struct\n", e)
+		} else {
+			ass.Fail(t, "Test should result in recovered panic.")
 		}
 	}()
 	col.RankValues(s, s) // This should panic.
@@ -386,6 +394,8 @@ func TestRankRecursiveArrays(t *tes.T) {
 	defer func() {
 		if e := recover(); e != nil {
 			ass.Equal(t, "The maximum recursion depth was exceeded: 100", e)
+		} else {
+			ass.Fail(t, "Test should result in recovered panic.")
 		}
 	}()
 	col.RankValues(array, array) // This should panic.
@@ -397,6 +407,8 @@ func TestRankRecursiveMaps(t *tes.T) {
 	defer func() {
 		if e := recover(); e != nil {
 			ass.Equal(t, "The maximum recursion depth was exceeded: 100", e)
+		} else {
+			ass.Fail(t, "Test should result in recovered panic.")
 		}
 	}()
 	col.RankValues(m, m) // This should panic.

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -37,12 +37,12 @@ var v6 rune = '☺'
 var v7 string = "Hello World!"
 var v8 = []int{1, 2, 3}
 
-func TestFormatterWithIndentation(t *tes.T) {
+func TestFormatWithIndentation(t *tes.T) {
 	var formatter = col.Formatter(1)
 	ass.Equal(t, 1, formatter.GetIndentation())
 }
 
-func TestFormatterWithPrimitives(t *tes.T) {
+func TestFormatPrimitives(t *tes.T) {
 	var s0 = col.FormatValue(nil)
 	ass.Equal(t, "<nil>", s0)
 	fmt.Println("\nNil: " + s0)
@@ -76,35 +76,35 @@ func TestFormatterWithPrimitives(t *tes.T) {
 	fmt.Println("\nString: " + s7)
 }
 
-func TestFormatterWithEmptyArray(t *tes.T) {
+func TestFormatEmptyArray(t *tes.T) {
 	var array = []any{}
 	var s = col.FormatValue(array)
 	ass.Equal(t, "[ ](array)", s)
 	fmt.Println("\nEmpty Array: " + s)
 }
 
-func TestFormatterWithArrayOfAny(t *tes.T) {
+func TestFormatArrayOfAny(t *tes.T) {
 	var array = []any{v1, v2, v3, v4, v5, v6, v7, v8}
 	var s = col.FormatValue(array)
 	ass.Equal(t, "(array)", s[len(s)-7:])
 	fmt.Println("\nArray of Any: " + s)
 }
 
-func TestFormatterWithArrayOfIntegers(t *tes.T) {
+func TestFormatArrayOfIntegers(t *tes.T) {
 	var array = []int{1, 2, 3, 4}
 	var s = col.FormatValue(array)
 	ass.Equal(t, "(array)", s[len(s)-7:])
 	fmt.Println("\nArray of Integers: " + s)
 }
 
-func TestFormatterWithEmptyMap(t *tes.T) {
+func TestFormatEmptyMap(t *tes.T) {
 	var mapp = map[any]any{}
 	var s = col.FormatValue(mapp)
 	ass.Equal(t, "[:](map)", s)
 	fmt.Println("\nEmpty Map: " + s)
 }
 
-func TestFormatterWithMapOfAnyToAny(t *tes.T) {
+func TestFormatMapOfAnyToAny(t *tes.T) {
 	var mapp = map[any]any{
 		k1: v1,
 		k2: v2,
@@ -119,7 +119,7 @@ func TestFormatterWithMapOfAnyToAny(t *tes.T) {
 	fmt.Println("\nMap of Any to Any: " + s)
 }
 
-func TestFormatterWithMapOfStringToInteger(t *tes.T) {
+func TestFormatMapOfStringToInteger(t *tes.T) {
 	var mapp = map[string]int{
 		"first":  1,
 		"second": 2,
@@ -129,14 +129,14 @@ func TestFormatterWithMapOfStringToInteger(t *tes.T) {
 	fmt.Println("\nMap of String to Integer: " + s)
 }
 
-func TestFormatterWithEmptyList(t *tes.T) {
+func TestFormatEmptyList(t *tes.T) {
 	var list = col.List[any]()
 	var s = col.FormatValue(list)
 	ass.Equal(t, "[ ](list)", s)
 	fmt.Println("\nEmpty List: " + s)
 }
 
-func TestFormatterWithListOfAny(t *tes.T) {
+func TestFormatListOfAny(t *tes.T) {
 	var list = col.ListFromArray[any]([]any{v1, v2, v3, v4, v5, v6, v7, v8})
 	var s = col.FormatValue(list)
 	ass.Equal(t, s, fmt.Sprintf("%s", list))
@@ -144,13 +144,13 @@ func TestFormatterWithListOfAny(t *tes.T) {
 	fmt.Println("\nList of Any: " + s)
 }
 
-func TestFormatterWithListOfBoolean(t *tes.T) {
+func TestFormatListOfBoolean(t *tes.T) {
 	var list = col.ListFromArray[bool]([]bool{k1, v1})
 	var s = col.FormatValue(list)
 	fmt.Println("\nList of Boolean: " + s)
 }
 
-func TestFormatterWithSetOfAny(t *tes.T) {
+func TestFormatSetOfAny(t *tes.T) {
 	var set = col.SetFromArray[any]([]any{v1, v2, v3, v4, v5, v6, v7, v8})
 	var s = col.FormatValue(set)
 	ass.Equal(t, s, fmt.Sprintf("%s", set))
@@ -158,7 +158,7 @@ func TestFormatterWithSetOfAny(t *tes.T) {
 	fmt.Println("\nSet of Any: " + s)
 }
 
-func TestFormatterWithSetOfSet(t *tes.T) {
+func TestFormatSetOfSet(t *tes.T) {
 	var set1 = col.SetFromArray[any]([]any{v1, v2, v3, v4, v5, v6, v7, v8})
 	var set2 = col.SetFromArray[any]([]any{k1, k2, k3, k4, k5, k6, k7, k8})
 	var set = col.SetFromArray[col.SetLike[any]]([]col.SetLike[any]{set1, set2})
@@ -166,7 +166,7 @@ func TestFormatterWithSetOfSet(t *tes.T) {
 	fmt.Println("\nSet of Set: " + s)
 }
 
-func TestFormatterWithStackOfAny(t *tes.T) {
+func TestFormatStackOfAny(t *tes.T) {
 	var stack = col.Stack[any]()
 	stack.AddValue(v1)
 	stack.AddValue(v2)
@@ -181,7 +181,7 @@ func TestFormatterWithStackOfAny(t *tes.T) {
 	fmt.Println("\nStack: " + s)
 }
 
-func TestFormatterWithQueueOfAny(t *tes.T) {
+func TestFormatQueueOfAny(t *tes.T) {
 	var queue col.FIFO[any] = col.Queue[any]()
 	queue.AddValue(v1)
 	queue.AddValue(v2)
@@ -196,27 +196,27 @@ func TestFormatterWithQueueOfAny(t *tes.T) {
 	fmt.Println("\nQueue: " + s)
 }
 
-func TestFormatterWithAssociationOfAnyToAny(t *tes.T) {
+func TestFormatAssociationOfAnyToAny(t *tes.T) {
 	var association = col.Association[any, any]("foo", 5)
 	var s = col.FormatValue(association)
 	ass.Equal(t, s, fmt.Sprintf("%s", association))
 	fmt.Println("\nAssociation of Any to Any: " + s)
 }
 
-func TestFormatterWithAssociationOfStringToInteger(t *tes.T) {
+func TestFormatAssociationOfStringToInteger(t *tes.T) {
 	var association = col.Association[string, int]("bar", 42)
 	var s = col.FormatValue(association)
 	fmt.Println("\nAssociation of String to Integer: " + s)
 }
 
-func TestFormatterWithEmptyCatalog(t *tes.T) {
+func TestFormatEmptyCatalog(t *tes.T) {
 	var catalog = col.Catalog[any, any]()
 	var s = col.FormatValue(catalog)
 	ass.Equal(t, "[:](catalog)", s)
 	fmt.Println("\nEmpty Catalog: " + s)
 }
 
-func TestFormatterWithCatalogOfAnyToAny(t *tes.T) {
+func TestFormatCatalogOfAnyToAny(t *tes.T) {
 	var catalog = col.Catalog[any, any]()
 	catalog.SetValue(k1, v1)
 	catalog.SetValue(k2, v2)
@@ -231,7 +231,7 @@ func TestFormatterWithCatalogOfAnyToAny(t *tes.T) {
 	fmt.Println("\nCatalog: " + s)
 }
 
-func TestFormatterWithCatalogOfStringToAny(t *tes.T) {
+func TestFormatCatalogOfStringToAny(t *tes.T) {
 	var catalog = col.Catalog[string, any]()
 	catalog.SetValue("key1", v1)
 	catalog.SetValue("key2", v2)
@@ -244,7 +244,7 @@ func TestFormatterWithCatalogOfStringToAny(t *tes.T) {
 	fmt.Println("\nCatalog of String to Any: " + s)
 }
 
-func TestFormatterWithCatalogOfStringToInteger(t *tes.T) {
+func TestFormatCatalogOfStringToInteger(t *tes.T) {
 	var catalog = col.Catalog[string, int]()
 	catalog.SetValue("key1", 1)
 	catalog.SetValue("key2", 2)
@@ -255,4 +255,14 @@ func TestFormatterWithCatalogOfStringToInteger(t *tes.T) {
 	catalog.SetValue("key7", 7)
 	var s = col.FormatValue(catalog)
 	fmt.Println("\nCatalog of String to Integer: " + s)
+}
+
+func TestFormatInvalidType(t *tes.T) {
+	var s struct{}
+	defer func() {
+		if e := recover(); e != nil {
+			ass.Equal(t, "Attempted to format:\n\tvalue: {}\n\ttype: struct {}\n\tkind: struct\n", e)
+		}
+	}()
+	col.FormatValue(s) // This should panic.
 }

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -262,6 +262,8 @@ func TestFormatInvalidType(t *tes.T) {
 	defer func() {
 		if e := recover(); e != nil {
 			ass.Equal(t, "Attempted to format:\n\tvalue: {}\n\ttype: struct {}\n\tkind: struct\n", e)
+		} else {
+			ass.Fail(t, "Test should result in recovered panic.")
 		}
 	}()
 	col.FormatValue(s) // This should panic.

--- a/iterator.go
+++ b/iterator.go
@@ -59,7 +59,7 @@ func (v *iterator[V]) ToEnd() {
 	v.slot = v.size
 }
 
-// This method determines whether or not there is an value before the current
+// This method determines whether or not there is a value before the current
 // slot.
 func (v *iterator[V]) HasPrevious() bool {
 	return v.slot > 0
@@ -75,7 +75,7 @@ func (v *iterator[V]) GetPrevious() V {
 	return result
 }
 
-// This method determines whether or not there is an value after the current
+// This method determines whether or not there is a value after the current
 // slot.
 func (v *iterator[V]) HasNext() bool {
 	return v.slot < v.size

--- a/queue.go
+++ b/queue.go
@@ -36,10 +36,10 @@ func QueueWithCapacity[V Value](capacity int) QueueLike[V] {
 }
 
 // This function connects the output of the specified input queue with a
-// number of new output queues specified by the size parameter and returns an
-// array of the new output queues. Each value added to the input queue will be
-// added automatically to ALL of the output queues. This pattern is useful when
-// a set of DIFFERENT operations needs to occur for every value and each
+// number of new output queues specified by the size parameter and returns a
+// sequence of the new output queues. Each value added to the input queue will
+// be added automatically to ALL of the output queues. This pattern is useful
+// when a set of DIFFERENT operations needs to occur for every value and each
 // operation can be done in parallel.
 func Fork[V Value](wg *syn.WaitGroup, input FIFO[V], size int) Sequential[FIFO[V]] {
 	// Validate the arguments.
@@ -88,13 +88,13 @@ func Fork[V Value](wg *syn.WaitGroup, input FIFO[V], size int) Sequential[FIFO[V
 	return outputs
 }
 
-// This function connects the output of the specified input queue with
-// the number of output queues specified by the size parameter and returns an
-// array of the new output queues. Each value added to the input queue will be
-// added automatically to ONE of the output queues. This pattern is useful when
-// a SINGLE operation needs to occur for each value and the operation can be done
-// on the values in parallel. The results can then be consolidated later on using
-// the Join() function.
+// This function connects the output of the specified input queue with the
+// number of output queues specified by the size parameter and returns a
+// sequence of the new output queues. Each value added to the input queue will
+// be added automatically to ONE of the output queues. This pattern is useful
+// when a SINGLE operation needs to occur for each value and the operation can
+// be done on the values in parallel. The results can then be consolidated later
+// on using the Join() function.
 func Split[V Value](wg *syn.WaitGroup, input FIFO[V], size int) Sequential[FIFO[V]] {
 	// Validate the arguments.
 	if size < 2 {
@@ -142,7 +142,7 @@ func Split[V Value](wg *syn.WaitGroup, input FIFO[V], size int) Sequential[FIFO[
 	return outputs
 }
 
-// This function connects the outputs of the specified array of input
+// This function connects the outputs of the specified sequence of input
 // queues with a new output queue returns the new output queue. Each value
 // removed from each input queue will automatically be added to the output
 // queue. This pattern is useful when the results of the processing with a

--- a/queue.go
+++ b/queue.go
@@ -43,8 +43,8 @@ func QueueWithCapacity[V Value](capacity int) QueueLike[V] {
 // operation can be done in parallel.
 func Fork[V Value](wg *syn.WaitGroup, input FIFO[V], size int) Sequential[FIFO[V]] {
 	// Validate the arguments.
-	if size < 1 {
-		panic("The fan out size for a queue must be greater than zero.")
+	if size < 2 {
+		panic("The fan out size for a queue must be greater than one.")
 	}
 
 	// Create the new output queues.
@@ -97,8 +97,8 @@ func Fork[V Value](wg *syn.WaitGroup, input FIFO[V], size int) Sequential[FIFO[V
 // the Join() function.
 func Split[V Value](wg *syn.WaitGroup, input FIFO[V], size int) Sequential[FIFO[V]] {
 	// Validate the arguments.
-	if size < 1 {
-		panic("The size of the split must be greater than zero.")
+	if size < 2 {
+		panic("The size of the split must be greater than one.")
 	}
 
 	// Create the new output queues.
@@ -150,7 +150,7 @@ func Split[V Value](wg *syn.WaitGroup, input FIFO[V], size int) Sequential[FIFO[
 func Join[V Value](wg *syn.WaitGroup, inputs Sequential[FIFO[V]]) FIFO[V] {
 	// Validate the arguments.
 	if inputs == nil || inputs.IsEmpty() {
-		panic("The number of input queues for a join must be greater than zero.")
+		panic("The number of input queues for a join must be at least one.")
 	}
 
 	// Create the new output queue.

--- a/queue.go
+++ b/queue.go
@@ -269,7 +269,7 @@ func (v *queue[V]) RemoveHead() (V, bool) {
 	var ok bool
 
 	// Remove the head value from the queue if one exists.
-	_, ok = <-v.available // Will block until an value is available.
+	_, ok = <-v.available // Will block until a value is available.
 	if ok {
 		v.mutex.Lock()
 		head = v.values.RemoveValue(1)

--- a/queue_test.go
+++ b/queue_test.go
@@ -90,6 +90,23 @@ func TestQueueWithFork(t *tes.T) {
 	input.CloseQueue()
 }
 
+func TestQueueWithInvalidFanOut(t *tes.T) {
+	// Create a wait group for synchronization.
+	var wg = new(syn.WaitGroup)
+	defer wg.Wait()
+
+	// Create a new queue with an invalid fan out.
+	var input col.FIFO[int] = col.QueueWithCapacity[int](3)
+	defer func() {
+		if e := recover(); e != nil {
+			ass.Equal(t, "The fan out size for a queue must be greater than one.", e)
+		} else {
+			ass.Fail(t, "Test should result in recovered panic.")
+		}
+	}()
+	col.Fork(wg, input, 1) // Should panic here.
+}
+
 func TestQueueWithSplitAndJoin(t *tes.T) {
 	// Create a wait group for synchronization.
 	var wg = new(syn.WaitGroup)
@@ -119,4 +136,39 @@ func TestQueueWithSplitAndJoin(t *tes.T) {
 		input.AddValue(i)
 	}
 	input.CloseQueue()
+}
+
+func TestQueueWithInvalidSplit(t *tes.T) {
+	// Create a wait group for synchronization.
+	var wg = new(syn.WaitGroup)
+	defer wg.Wait()
+
+	// Create a new queue with an invalid fan out.
+	var input col.FIFO[int] = col.QueueWithCapacity[int](3)
+	defer func() {
+		if e := recover(); e != nil {
+			ass.Equal(t, "The size of the split must be greater than one.", e)
+		} else {
+			ass.Fail(t, "Test should result in recovered panic.")
+		}
+	}()
+	col.Split(wg, input, 1) // Should panic here.
+}
+
+func TestQueueWithInvalidJoin(t *tes.T) {
+	// Create a wait group for synchronization.
+	var wg = new(syn.WaitGroup)
+	defer wg.Wait()
+
+	// Create a new queue with an invalid fan out.
+	var inputs col.Sequential[col.FIFO[int]] = col.List[col.FIFO[int]]()
+	defer func() {
+		if e := recover(); e != nil {
+			ass.Equal(t, "The number of input queues for a join must be at least one.", e)
+		} else {
+			ass.Fail(t, "Test should result in recovered panic.")
+		}
+	}()
+	col.Join(wg, inputs) // Should panic here.
+	defer wg.Done()
 }

--- a/set_test.go
+++ b/set_test.go
@@ -120,7 +120,6 @@ func TestSetWithNot(t *tes.T) {
 	col.Not(set) // This should panic.
 }
 
-
 func TestSetsWithAnd(t *tes.T) {
 	var list1 = col.ListFromArray([]int{3, 1, 2})
 	var list2 = col.ListFromArray([]int{3, 2, 4})

--- a/set_test.go
+++ b/set_test.go
@@ -108,6 +108,19 @@ func TestSetsWithSets(t *tes.T) {
 	ass.Equal(t, 0, set.GetSize())
 }
 
+func TestSetWithNot(t *tes.T) {
+	var set = col.Set[int]()
+	defer func() {
+		if e := recover(); e != nil {
+			ass.Equal(t, "Not(set) is meaningless, use Sans(fullSet, set) instead.", e)
+		} else {
+			ass.Fail(t, "Test should result in recovered panic.")
+		}
+	}()
+	col.Not(set) // This should panic.
+}
+
+
 func TestSetsWithAnd(t *tes.T) {
 	var list1 = col.ListFromArray([]int{3, 1, 2})
 	var list2 = col.ListFromArray([]int{3, 2, 4})

--- a/sorter.go
+++ b/sorter.go
@@ -91,6 +91,7 @@ func (v *sorter[V]) shuffleArray(array []V) {
 func randomIndex(size int) int {
 	var random, err = ran.Int(ran.Reader, big.NewInt(int64(size)))
 	if err != nil {
+		// There was an issue with the underlying OS so time to...
 		panic("Unable to generate a random index:\n" + err.Error())
 	}
 	return int(random.Int64())

--- a/sorter.go
+++ b/sorter.go
@@ -91,7 +91,7 @@ func (v *sorter[V]) shuffleArray(array []V) {
 func randomIndex(size int) int {
 	var random, err = ran.Int(ran.Reader, big.NewInt(int64(size)))
 	if err != nil {
-		panic(err)
+		panic("Unable to generate a random index:\n" + err.Error())
 	}
 	return int(random.Int64())
 }

--- a/stack.go
+++ b/stack.go
@@ -62,7 +62,7 @@ func (v *stack[V]) GetCapacity() int {
 func (v *stack[V]) AddValue(value V) {
 	if v.values.GetSize() == v.capacity {
 		panic(fmt.Sprintf(
-			"Attempted to add an value onto a stack that has reached its capacity: %v\nvalue: %v\nstack: %v\n",
+			"Attempted to add a value onto a stack that has reached its capacity: %v\nvalue: %v\nstack: %v\n",
 			v.capacity,
 			value,
 			v))

--- a/stack.go
+++ b/stack.go
@@ -10,6 +10,10 @@
 
 package collections
 
+import (
+	fmt "fmt"
+)
+
 // STACK IMPLEMENTATION
 
 // This constructor creates a new empty stack with the default capacity.
@@ -57,7 +61,11 @@ func (v *stack[V]) GetCapacity() int {
 // This method adds the specified value to the top of this stack.
 func (v *stack[V]) AddValue(value V) {
 	if v.values.GetSize() == v.capacity {
-		panic("Attempted to add an value onto a stack that has reached its capacity!")
+		panic(fmt.Sprintf(
+			"Attempted to add an value onto a stack that has reached its capacity: %v\nvalue: %v\nstack: %v\n",
+			v.capacity,
+			value,
+			v))
 	}
 	v.values.AddValue(value)
 }

--- a/stack_test.go
+++ b/stack_test.go
@@ -16,6 +16,43 @@ import (
 	tes "testing"
 )
 
+func TestStackWithSmallCapacity(t *tes.T) {
+	var stack = col.StackWithCapacity[int](1)
+	stack.AddValue(1)
+	defer func() {
+		if e := recover(); e != nil {
+			ass.Equal(t, "Attempted to add a value onto a stack that has reached its capacity: 1\nvalue: 2\nstack: [\n\t1\n](stack)\n", e)
+		} else {
+			ass.Fail(t, "Test should result in recovered panic.")
+		}
+	}()
+	stack.AddValue(2) // This should panic.
+}
+
+func TestEmptyStackRetrieval(t *tes.T) {
+	var stack = col.Stack[int]()
+	defer func() {
+		if e := recover(); e != nil {
+			ass.Equal(t, "Attempted to retrieve the top of an empty stack!", e)
+		} else {
+			ass.Fail(t, "Test should result in recovered panic.")
+		}
+	}()
+	stack.GetTop() // This should panic.
+}
+
+func TestEmptyStackRemoval(t *tes.T) {
+	var stack = col.Stack[int]()
+	defer func() {
+		if e := recover(); e != nil {
+			ass.Equal(t, "Attempted to remove the top of an empty stack!", e)
+		} else {
+			ass.Fail(t, "Test should result in recovered panic.")
+		}
+	}()
+	stack.RemoveTop() // This should panic.
+}
+
 func TestStacksWithStrings(t *tes.T) {
 	var stack = col.Stack[string]()
 	ass.True(t, stack.IsEmpty())


### PR DESCRIPTION
This pull request addresses issue #3: 

A summary of the changes included in this pull request:
 1. Some general cleanup of comments within the code.
 1. The wording of the panic strings has been improved and clarified.
 1. Unit tests for each (possible) panic situation have been added to the test cases.
 1. Where relevant the collection (if any) associated with a panic is formatted within the panic string.

To be reviewed by: @derknorton
