### PR TITLE
Deprecated the Indexed[V].GoIndex() method and moved it to a Go speci…

### DIFF
--- a/abstractions.go
+++ b/abstractions.go
@@ -59,6 +59,8 @@ type Indexed[V Value] interface {
 	GetValue(index int) V
 	GetValues(first int, last int) Sequential[V]
 	GetIndex(value V) int
+	// Deprecated: The GoIndex method should not be in a high-level interface
+	// and will be removed from this interface during the next major release.
 	GoIndex(index int) int
 }
 

--- a/array.go
+++ b/array.go
@@ -24,12 +24,6 @@ import (
 //   - V is any type of value.
 type Array[V Value] []V
 
-// STRINGER INTERFACE
-
-func (v Array[V]) String() string {
-	return FormatValue(v)
-}
-
 // SEQUENTIAL INTERFACE
 
 // This method determines whether or not this array is empty.
@@ -80,40 +74,6 @@ func (v Array[V]) GetIndex(value V) int {
 	}
 	// The value was not found.
 	return 0
-}
-
-// This method normalizes an index to match the Go (zero based) indexing. The
-// following transformation is performed:
-//
-//	[-length..-1] and [1..length] => [0..length)
-//
-// Notice that the specified index cannot be zero since zero is not an ORDINAL.
-func (v Array[V]) GoIndex(index int) int {
-	var length = len(v)
-	switch {
-	case length == 0:
-		// The array is empty.
-		panic("Cannot index an empty array.")
-	case index == 0:
-		// Zero is not an ordinal.
-		panic("Indices must be positive or negative ordinals, not zero.")
-	case index < -length || index > length:
-		// The index is outside the bounds of the specified range.
-		panic(fmt.Sprintf(
-			"The specified index is outside the allowed ranges [-%v..-1] and [1..%v]: %v",
-			length,
-			length,
-			index))
-	case index < 0:
-		// Convert a negative index.
-		return index + length
-	case index > 0:
-		// Convert a positive index.
-		return index - 1
-	default:
-		// This should never happen so time to...
-		panic(fmt.Sprintf("Go compiler problem, unexpected index value: %v", index))
-	}
 }
 
 // SEARCHABLE INTERFACE
@@ -167,4 +127,45 @@ func (v Array[V]) SetValue(index int, value V) {
 func (v Array[V]) SetValues(index int, values Sequential[V]) {
 	index = v.GoIndex(index)
 	copy(v[index:], values.AsArray())
+}
+
+// GO INTERFACE
+
+// This method is used by Go to generate a string from an array.
+func (v Array[V]) String() string {
+	return FormatValue(v)
+}
+
+// This method normalizes an index to match the Go (zero based) indexing. The
+// following transformation is performed:
+//
+//	[-length..-1] and [1..length] => [0..length)
+//
+// Notice that the specified index cannot be zero since zero is not an ORDINAL.
+func (v Array[V]) GoIndex(index int) int {
+	var length = len(v)
+	switch {
+	case length == 0:
+		// The array is empty.
+		panic("Cannot index an empty array.")
+	case index == 0:
+		// Zero is not an ordinal.
+		panic("Indices must be positive or negative ordinals, not zero.")
+	case index < -length || index > length:
+		// The index is outside the bounds of the specified range.
+		panic(fmt.Sprintf(
+			"The specified index is outside the allowed ranges [-%v..-1] and [1..%v]: %v",
+			length,
+			length,
+			index))
+	case index < 0:
+		// Convert a negative index.
+		return index + length
+	case index > 0:
+		// Convert a positive index.
+		return index - 1
+	default:
+		// This should never happen so time to...
+		panic(fmt.Sprintf("Go compiler problem, unexpected index value: %v", index))
+	}
 }

--- a/list.go
+++ b/list.go
@@ -67,7 +67,7 @@ func Concatenate[V Value](first, second ListLike[V]) ListLike[V] {
 //   - V is any type of value.
 type list[V Value] struct {
 	ArrayLike[V]
-	values  []V
+	values  Array[V]
 	compare ComparisonFunction
 }
 
@@ -130,7 +130,7 @@ func (v *list[V]) InsertValues(slot int, values Sequential[V]) {
 // removed value is returned.
 func (v *list[V]) RemoveValue(index int) V {
 	// Remove the old value.
-	index = v.GoIndex(index)
+	index = v.values.GoIndex(index)
 	var old = v.values[index]
 	copy(v.values[index:], v.values[index+1:])
 
@@ -144,8 +144,8 @@ func (v *list[V]) RemoveValue(index int) V {
 // The removed values are returned.
 func (v *list[V]) RemoveValues(first int, last int) Sequential[V] {
 	// Remove the specified values.
-	first = v.GoIndex(first)
-	last = v.GoIndex(last)
+	first = v.values.GoIndex(first)
+	last = v.values.GoIndex(last)
 	var result = ListFromArray(v.values[first : last+1])
 	copy(v.values[first:], v.values[last+1:])
 


### PR DESCRIPTION
…fic interface implemented only by the Array[V] type.

This pull request addresses issue #8: 

A summary of the changes included in this pull request:
 1. Marked the `GoIndex()` method in the `Indexed[V]` interface as deprecated.
 2. Moved the implementation of the `GoIndex()` method to a Go specific interface in the `Array[V]` type.
 3. Changed the type of the `values` attribute in the `list[V]` structure from `[]V` to `Array[V]`.

All other collection types continue to work the same for now.

To be reviewed by: @derknorton
