### PR TITLE
Fixed issue 10 regarding the handling of tilda types by the collator.

### DIFF
--- a/abstractions.go
+++ b/abstractions.go
@@ -13,7 +13,7 @@ This collections package defines a set of simple, pragmatic interfaces for
 collections of sequential values. It also provides efficient and compact
 implementations of the following collection types based on those interfaces:
   - array (native Go array)
-  - list (a sortable array)
+  - list (a sortable list)
   - set (an ordered set)
   - map (native Go map)
   - catalog (a sortable map)

--- a/collator_test.go
+++ b/collator_test.go
@@ -155,6 +155,55 @@ func TestComparison(t *tes.T) {
 	ass.True(t, col.CompareValues(m2, m2))
 }
 
+type Boolean bool
+type Integer int
+type String string
+
+func TestTildaTypes(t *tes.T) {
+	// Boolean
+	var False = Boolean(false)
+	var True = Boolean(true)
+	var ShouldBeFalse Boolean
+
+	ass.Equal(t, 0, col.RankValues(ShouldBeFalse, ShouldBeFalse))
+	ass.Equal(t, -1, col.RankValues(ShouldBeFalse, True))
+	ass.Equal(t, 0, col.RankValues(False, ShouldBeFalse))
+	ass.Equal(t, 1, col.RankValues(True, ShouldBeFalse))
+	ass.Equal(t, 0, col.RankValues(ShouldBeFalse, False))
+	ass.Equal(t, -1, col.RankValues(False, True))
+	ass.Equal(t, 0, col.RankValues(False, False))
+	ass.Equal(t, 1, col.RankValues(True, False))
+	ass.Equal(t, 0, col.RankValues(True, True))
+
+	// Integer
+	var Zilch = Integer(0)
+	var Two = Integer(2)
+	var Three = Integer(3)
+	var ShouldBeZilch Integer
+
+	ass.True(t, col.CompareValues(ShouldBeZilch, Zilch))
+	ass.False(t, col.CompareValues(Two, ShouldBeZilch))
+
+	ass.False(t, col.CompareValues(Two, Three))
+	ass.True(t, col.CompareValues(Two, Two))
+	ass.False(t, col.CompareValues(Three, Two))
+	ass.True(t, col.CompareValues(Three, Three))
+
+	// String
+	var Empty = String("")
+	var Hello = String("Hello")
+	var World = String("World")
+	var ShouldBeEmpty String
+
+	ass.True(t, col.CompareValues(ShouldBeEmpty, Empty))
+	ass.False(t, col.CompareValues(Hello, ShouldBeEmpty))
+
+	ass.False(t, col.CompareValues(World, Hello))
+	ass.True(t, col.CompareValues(World, World))
+	ass.False(t, col.CompareValues(Hello, World))
+	ass.True(t, col.CompareValues(Hello, Hello))
+}
+
 func TestCompareInvalidTypes(t *tes.T) {
 	var s struct{}
 	defer func() {
@@ -374,6 +423,19 @@ func TestRanking(t *tes.T) {
 	ass.Equal(t, 0, col.RankValues(m4, m4))
 	ass.Equal(t, 1, col.RankValues(m1, m4))
 	ass.Equal(t, 0, col.RankValues(m1, m1))
+}
+
+func TestTildaArrays(t *tes.T) {
+	var alpha = String("alpha")
+	var beta = String("beta")
+	var gamma = String("gamma")
+	var delta = String("delta")
+	var array = []String{alpha, beta, gamma, delta}
+	col.SortArray(array, col.RankValues)
+	ass.Equal(t, alpha, array[0])
+	ass.Equal(t, beta, array[1])
+	ass.Equal(t, delta, array[2])
+	ass.Equal(t, gamma, array[3])
 }
 
 func TestRankInvalidTypes(t *tes.T) {

--- a/iterator.go
+++ b/iterator.go
@@ -13,7 +13,7 @@ package collections
 // ITERATOR IMPLEMENTATION
 
 // This constructor creates a new instance of an iterator that can be used to
-// traverse the values in the specified array.
+// traverse the values in the specified sequence.
 func Iterator[V Value](sequence Sequential[V]) IteratorLike[V] {
 	var values = sequence.AsArray() // The returned array is immutable.
 	var size = len(values)

--- a/list_test.go
+++ b/list_test.go
@@ -140,6 +140,17 @@ func TestListsWithStrings(t *tes.T) {
 	ass.Equal(t, "bar", string(list.GetValue(1)))                      // ["bar", "foo"]
 }
 
+func TestListsWithTildas(t *tes.T) {
+	var list = col.ListFromArray([]Integer{3, 1, 4, 5, 9, 2})
+	ass.False(t, list.IsEmpty())            // [3,1,4,5,9,2]
+	ass.Equal(t, 6, list.GetSize())         // [3,1,4,5,9,2]
+	ass.Equal(t, 3, int(list.GetValue(1)))  // [3,1,4,5,9,2]
+	ass.Equal(t, 2, int(list.GetValue(-1))) // [3,1,4,5,9,2]
+	list.SortValues()                       // [1,2,3,4,5,9]
+	ass.Equal(t, 6, list.GetSize())         // [1,2,3,4,5,9]
+	ass.Equal(t, 3, int(list.GetValue(3)))  // [1,2,3,4,5,9]
+}
+
 func TestListsWithConcatenate(t *tes.T) {
 	var list1 = col.List[int]()
 	var onetwothree = col.ListFromArray([]int{1, 2, 3})

--- a/set_test.go
+++ b/set_test.go
@@ -83,9 +83,24 @@ func TestSetsWithIntegers(t *tes.T) {
 	ass.Equal(t, 9, int(set.GetValue(-1))) // [1,2,3,4,5,9]
 	set.RemoveValue(6)                     // [1,2,3,4,5,9]
 	ass.Equal(t, 6, set.GetSize())         // [1,2,3,4,5,9]
-	set.RemoveValue(3)                     // [1,2,3,4,5,9]
-	ass.Equal(t, 5, set.GetSize())         // [1,2,3,4,5,9]
-	ass.Equal(t, 4, int(set.GetValue(3)))  // [1,2,3,4,5,9]
+	set.RemoveValue(3)                     // [1,2,4,5,9]
+	ass.Equal(t, 5, set.GetSize())         // [1,2,4,5,9]
+	ass.Equal(t, 4, int(set.GetValue(3)))  // [1,2,4,5,9]
+}
+
+func TestSetsWithTildas(t *tes.T) {
+	var list = col.ListFromArray([]Integer{3, 1, 4, 5, 9, 2})
+	var set = col.Set[Integer]()           // [ ]
+	set.AddValues(list)                    // [1,2,3,4,5,9]
+	ass.False(t, set.IsEmpty())            // [1,2,3,4,5,9]
+	ass.Equal(t, 6, set.GetSize())         // [1,2,3,4,5,9]
+	ass.Equal(t, 1, int(set.GetValue(1)))  // [1,2,3,4,5,9]
+	ass.Equal(t, 9, int(set.GetValue(-1))) // [1,2,3,4,5,9]
+	set.RemoveValue(6)                     // [1,2,3,4,5,9]
+	ass.Equal(t, 6, set.GetSize())         // [1,2,3,4,5,9]
+	set.RemoveValue(3)                     // [1,2,4,5,9]
+	ass.Equal(t, 5, set.GetSize())         // [1,2,4,5,9]
+	ass.Equal(t, 4, int(set.GetValue(3)))  // [1,2,4,5,9]
 }
 
 func TestSetsWithSets(t *tes.T) {


### PR DESCRIPTION
This pull request addresses issue #: 10

A summary of the changes included in this pull request:
 1. Split out a `rankElements()` method from the `rankValues()` method to be consistent with the structure of the `compareValues()` method.
 1. Implemented the `rankElements()` method using a reflective type switch that figures out which elemental (named) types are being ranked and then calls the specific ranking method for that type.
 1.Go does not make it easy to determine the elemental type of a value that may be a tilda type (e.g. ~string vs string) and does not let you cast between the two without knowing the actual type. To work around this we must convert the elemental (or corresponding tilda type) to a string and then parse it back again as the actual elemental (named) type.  This ugliness has been hidden in the new `rankElements()` method.

To be reviewed by: @derknorton
