### PR TITLE
Fixed issue 12 regarding default CompareValues() method being called …

### DIFF
--- a/list.go
+++ b/list.go
@@ -77,6 +77,23 @@ func (v *list[V]) String() string {
 	return FormatValue(v)
 }
 
+// INDEXED INTERFACE
+
+// This method returns the index of the FIRST occurrence of the specified value
+// in this list, or zero if this list does not contain the value. This method
+// overrides the array.GetIndex() method delegated to since that method always
+// uses the default comparer function.
+func (v *list[V]) GetIndex(value V) int {
+	for index, candidate := range v.values {
+		if v.compare(candidate, value) {
+			// Found the value.
+			return index + 1 // Convert to an ORDINAL based index.
+		}
+	}
+	// The value was not found.
+	return 0
+}
+
 // MALLEABLE INTERFACE
 
 // This method appends the specified value to the end of this list.

--- a/list_test.go
+++ b/list_test.go
@@ -151,6 +151,25 @@ func TestListsWithTildas(t *tes.T) {
 	ass.Equal(t, 3, int(list.GetValue(3)))  // [1,2,3,4,5,9]
 }
 
+func BadCompare(first col.Value, second col.Value) bool {
+	panic("KaPow!")
+}
+
+func TestListsWithComparer(t *tes.T) {
+	var list = col.ListWithComparer[int](BadCompare)
+	list.AddValue(1)
+	list.AddValue(2)
+	list.AddValue(3)
+	defer func() {
+		if e := recover(); e != nil {
+			ass.Equal(t, "KaPow!", e)
+		} else {
+			ass.Fail(t, "Test should result in recovered panic.")
+		}
+	}()
+	list.GetIndex(2)
+}
+
 func TestListsWithConcatenate(t *tes.T) {
 	var list1 = col.List[int]()
 	var onetwothree = col.ListFromArray([]int{1, 2, 3})


### PR DESCRIPTION
…by list.GetIndex() method.

This pull request addresses issue #: 12

A summary of the changes included in this pull request:
 1. Added a `list.GetIndex()` method that overrides the `array.GetIndex()` method. The `list.GetIndex()` calls the `CompareValues()` function assigned to the instance of the list.
 2. Added a unit test case that demonstrates that the `list.GetIndex()` is the method that gets called.

To be reviewed by: @derknorton
