### PR TITLE
Added getter method checking to enhancement 15.

### DIFF
--- a/collator.go
+++ b/collator.go
@@ -204,7 +204,6 @@ func (v *collator) compareSequences(first ref.Value, second ref.Value) bool {
 	return v.compareArrays(firstArray, secondArray)
 }
 
-
 // This private method determines whether or not the specified interfaces
 // have the same getter values.
 func (v *collator) compareInterfaces(first ref.Value, second ref.Value) bool {
@@ -294,7 +293,7 @@ func (v *collator) rankValues(first ref.Value, second ref.Value) int {
 	// Handle all Go structures.
 	case ref.Struct:
 		// Rank the corresponding fields for each structure.
-		var ranking = v.rankStructures(first, second) 
+		var ranking = v.rankStructures(first, second)
 		if ranking != 0 {
 			return ranking
 		}

--- a/collator.go
+++ b/collator.go
@@ -195,23 +195,6 @@ func (v *collator) compareMaps(first ref.Value, second ref.Value) bool {
 	return true
 }
 
-// This private method determines whether or not the specified associations have
-// the same key value pair.
-func (v *collator) compareAssociations(first ref.Value, second ref.Value) bool {
-	// Compare the keys of the two associations.
-	var firstKey = first.MethodByName("GetKey").Call([]ref.Value{})[0]
-	var secondKey = second.MethodByName("GetKey").Call([]ref.Value{})[0]
-	if !v.compareValues(firstKey, secondKey) {
-		// The keys don't match.
-		return false
-	}
-
-	// The keys match so compare the values of the two associations.
-	var firstValue = first.MethodByName("GetValue").Call([]ref.Value{})[0]
-	var secondValue = second.MethodByName("GetValue").Call([]ref.Value{})[0]
-	return v.compareValues(firstValue, secondValue)
-}
-
 // This private method determines whether or not the specified sequences
 // have the same value.
 func (v *collator) compareSequences(first ref.Value, second ref.Value) bool {
@@ -571,27 +554,6 @@ func (v *collator) rankMaps(first ref.Value, second ref.Value) int {
 
 	// All keys and values match.
 	return 0
-}
-
-// This private method returns the ranking order of the specified associations.
-func (v *collator) rankAssociations(first ref.Value, second ref.Value) int {
-	// Rank the keys of the two associations.
-	var firstKey = first.MethodByName("GetKey").Call([]ref.Value{})[0]
-	var secondKey = second.MethodByName("GetKey").Call([]ref.Value{})[0]
-	var keyRank = v.rankValues(firstKey, secondKey)
-	if keyRank < 0 {
-		// The key in the first association comes before the second.
-		return -1
-	}
-	if keyRank > 0 {
-		// The key in the first association comes after the second.
-		return 1
-	}
-
-	// The keys match so rank the values of the two associations.
-	var firstValue = first.MethodByName("GetValue").Call([]ref.Value{})[0]
-	var secondValue = second.MethodByName("GetValue").Call([]ref.Value{})[0]
-	return v.rankValues(firstValue, secondValue)
 }
 
 // This private method returns the ranking order of the specified sequences

--- a/collator_test.go
+++ b/collator_test.go
@@ -16,13 +16,23 @@ import (
 	tes "testing"
 )
 
+// Tilda Types
 type Boolean bool
 type Integer int
 type String string
+
+// Encapsulated Type
 type FooBar struct {
-	Foo int
-	Bar string
+	foo int
+	bar string
+	Baz bool
 }
+func (v *FooBar) GetFoo() int { return v.foo }
+func (v FooBar) GetFoo2() int { return v.foo }
+func (v *FooBar) GetBar() string { return v.bar }
+func (v FooBar) GetBar2() string { return v.bar }
+
+// Pure Structure
 type Fuz struct {
 	Bar string
 }
@@ -166,14 +176,25 @@ func TestComparison(t *tes.T) {
 	ass.True(t, col.CompareValues(m2, m2))
 
 	// Struct
-	var f1 = FooBar{1, "one"}
-	var f2 = FooBar{1, "one"}
-	var f3 = FooBar{2, "two"}
+	var f1 = &FooBar{1, "one", false}
+	var f2 = &FooBar{1, "one", false}
+	var f3 = &FooBar{2, "two", true}
 	var f4 = Fuz{"two"}
+	var f5 = Fuz{"two"}
+	var f6 = Fuz{"three"}
 	ass.True(t, col.CompareValues(f1, f1))
 	ass.True(t, col.CompareValues(f1, f2))
 	ass.False(t, col.CompareValues(f2, f3))
-	ass.False(t, col.CompareValues(f3, f4))
+	ass.True(t, col.CompareValues(*f1, *f1))
+	ass.True(t, col.CompareValues(*f1, *f2))
+	ass.False(t, col.CompareValues(*f2, *f3))
+	ass.False(t, col.CompareValues(*f3, f4))
+	ass.True(t, col.CompareValues(f4, f4))
+	ass.True(t, col.CompareValues(f4, f5))
+	ass.False(t, col.CompareValues(f5, f6))
+	ass.True(t, col.CompareValues(&f4, &f4))
+	ass.True(t, col.CompareValues(&f4, &f5))
+	ass.False(t, col.CompareValues(&f5, &f6))
 }
 
 func TestTildaTypes(t *tes.T) {
@@ -430,16 +451,30 @@ func TestRanking(t *tes.T) {
 	ass.Equal(t, 0, col.RankValues(m1, m1))
 
 	// Struct
-	var f1 = FooBar{1, "one"}
-	var f2 = FooBar{1, "two"}
-	var f3 = FooBar{2, "two"}
+	var f1 = &FooBar{1, "one", true}
+	var f2 = &FooBar{1, "two", true}
+	var f3 = &FooBar{2, "two", false}
 	var f4 = Fuz{"two"}
+	var f5 = Fuz{"two"}
+	var f6 = Fuz{"three"}
 	ass.Equal(t, 0, col.RankValues(f1, f1))
 	ass.Equal(t, -1, col.RankValues(f1, f2))
 	ass.Equal(t, -1, col.RankValues(f2, f3))
 	ass.Equal(t, 1, col.RankValues(f3, f1))
 	ass.Equal(t, 1, col.RankValues(f3, f2))
-	ass.Equal(t, -1, col.RankValues(f3, f4))
+	ass.Equal(t, 0, col.RankValues(*f1, *f1))
+	ass.Equal(t, -1, col.RankValues(*f1, *f2))
+	ass.Equal(t, 1, col.RankValues(*f2, *f3))
+	ass.Equal(t, -1, col.RankValues(*f3, *f1))
+	ass.Equal(t, -1, col.RankValues(*f3, *f2))
+	ass.Equal(t, -1, col.RankValues(*f3, f4))
+	ass.Equal(t, 0, col.RankValues(f4, f4))
+	ass.Equal(t, 0, col.RankValues(f4, f5))
+	ass.Equal(t, 1, col.RankValues(f5, f6))
+	ass.Equal(t, -1, col.RankValues(f3, &f4))
+	ass.Equal(t, 0, col.RankValues(&f4, &f4))
+	ass.Equal(t, 0, col.RankValues(&f4, &f5))
+	ass.Equal(t, 1, col.RankValues(&f5, &f6))
 }
 
 func TestTildaArrays(t *tes.T) {

--- a/collator_test.go
+++ b/collator_test.go
@@ -27,8 +27,9 @@ type FooBar struct {
 	bar string
 	Baz bool
 }
-func (v *FooBar) GetFoo() int { return v.foo }
-func (v FooBar) GetFoo2() int { return v.foo }
+
+func (v *FooBar) GetFoo() int    { return v.foo }
+func (v FooBar) GetFoo2() int    { return v.foo }
 func (v *FooBar) GetBar() string { return v.bar }
 func (v FooBar) GetBar2() string { return v.bar }
 


### PR DESCRIPTION
This pull request addresses issue #: 15

A summary of the changes included in this pull request:
 1. Added `compareInterfaces()` and `rankInterfaces()` methods to the collator so that the getter methods for two interfaces or structure references can be used to compare the values of encapsulated fields.
 2. Added unit tests for both encapsulated structure types and pure structure types. The tests operate on the structures and pointers to the structures to make sure all four combinations work as expected.

To be reviewed by: @derknorton
