### PR TITLE
26 v1 and v2 the collator isnt checking for nil values for interfaces pointers maps arrays and slices

### DIFF
--- a/collator.go
+++ b/collator.go
@@ -67,7 +67,7 @@ func (v *collator) RankValues(first Value, second Value) int {
 // This function determines whether or not the specified reflective values are
 // equal using reflection and a recursive descent algorithm.
 func (v *collator) compareValues(first ref.Value, second ref.Value) bool {
-	// Handle any nil pointers.
+	// Handle any invalid values.
 	if !first.IsValid() {
 		return !second.IsValid()
 	}
@@ -75,7 +75,7 @@ func (v *collator) compareValues(first ref.Value, second ref.Value) bool {
 		return false
 	}
 
-	// At this point, neither of the values are nil.
+	// At this point, neither of the values are invalid.
 	var firstType = baseTypeName(first.Type())
 	var secondType = baseTypeName(second.Type())
 	if firstType != secondType && firstType != "any" && secondType != "any" {
@@ -84,7 +84,7 @@ func (v *collator) compareValues(first ref.Value, second ref.Value) bool {
 	}
 
 	// We now know that the types of the values are the same, and neither of
-	// the values is nil.
+	// the values is invalid.
 	switch first.Kind() {
 
 	// Handle all native elemental types.
@@ -97,13 +97,31 @@ func (v *collator) compareValues(first ref.Value, second ref.Value) bool {
 
 	// Handle all native collection types.
 	case ref.Array, ref.Slice:
-		return v.compareArrays(first, second)
+		switch {
+		case first.IsNil():
+			return second.IsNil()
+		case second.IsNil():
+			return false // We know that first isn't nil.
+		default:
+			return v.compareArrays(first, second)
+		}
 	case ref.Map:
-		return v.compareMaps(first, second)
+		switch {
+		case first.IsNil():
+			return second.IsNil()
+		case second.IsNil():
+			return false // We know that first isn't nil.
+		default:
+			return v.compareMaps(first, second)
+		}
 
 	// Handle all interfaces and pointers.
 	case ref.Interface, ref.Pointer:
 		switch {
+		case first.IsNil():
+			return second.IsNil()
+		case second.IsNil():
+			return false // We know that first isn't nil.
 		case first.MethodByName("AsArray").IsValid():
 			// The value is a sequence.
 			return v.compareSequences(first, second)
@@ -208,10 +226,11 @@ func (v *collator) compareSequences(first ref.Value, second ref.Value) bool {
 // have the same getter values.
 func (v *collator) compareInterfaces(first ref.Value, second ref.Value) bool {
 	var typeRef = first.Type() // We know the structures are the same type.
-	var count = first.NumMethod()
+	var count = typeRef.NumMethod()
 	for index := 0; index < count; index++ {
-		var method = typeRef.Method(index)
-		if sts.HasPrefix(method.Name, "Get") {
+		var name = typeRef.Method(index).Name
+		var arguments = first.Method(index).Type().NumIn()
+		if sts.HasPrefix(name, "Get") && arguments == 0 {
 			var firstValue = first.Method(index).Call([]ref.Value{})[0]
 			var secondValue = second.Method(index).Call([]ref.Value{})[0]
 			if !v.compareValues(firstValue, secondValue) {
@@ -270,13 +289,43 @@ func (v *collator) rankValues(first ref.Value, second ref.Value) int {
 
 	// Handle all native collection types.
 	case ref.Array, ref.Slice:
-		return v.rankArrays(first, second)
+		switch {
+		case first.IsNil():
+			if second.IsNil() {
+				return 0
+			}
+			// Only the first value is nil.
+			return -1
+		case second.IsNil():
+			return 1 // We know that first isn't nil.
+		default:
+			return v.rankArrays(first, second)
+		}
 	case ref.Map:
-		return v.rankMaps(first, second)
+		switch {
+		case first.IsNil():
+			if second.IsNil() {
+				return 0
+			}
+			// Only the first value is nil.
+			return -1
+		case second.IsNil():
+			return 1 // We know that first isn't nil.
+		default:
+			return v.rankMaps(first, second)
+		}
 
 	// Handle all interfaces and pointers.
 	case ref.Interface, ref.Pointer:
 		switch {
+		case first.IsNil():
+			if second.IsNil() {
+				return 0
+			}
+			// Only the first value is nil.
+			return -1
+		case second.IsNil():
+			return 1 // We know that first isn't nil.
 		case first.MethodByName("AsArray").IsValid():
 			// The value is a collection.
 			return v.rankSequences(first, second)

--- a/collator_test.go
+++ b/collator_test.go
@@ -21,17 +21,29 @@ type Boolean bool
 type Integer int
 type String string
 
-// Encapsulated Type
-type FooBar struct {
-	foo int
-	bar string
-	Baz bool
+type Foolish interface {
+	GetFoo() int
+	GetBar() string
+	GetNil() Foolish
 }
 
-func (v *FooBar) GetFoo() int    { return v.foo }
-func (v FooBar) GetFoo2() int    { return v.foo }
-func (v *FooBar) GetBar() string { return v.bar }
-func (v FooBar) GetBar2() string { return v.bar }
+func FooBar(foo int, bar string, baz Foolish) Foolish {
+	return &foobar{foo, bar, baz}
+}
+
+// Encapsulated Type
+type foobar struct {
+	foo int
+	bar string
+	Baz Foolish
+}
+
+func (v *foobar) GetFoo() int     { return v.foo }
+func (v foobar) GetFoo2() int     { return v.foo }
+func (v *foobar) GetBar() string  { return v.bar }
+func (v foobar) GetBar2() string  { return v.bar }
+func (v *foobar) GetNil() Foolish { return nil }
+func (v foobar) GetNil2() Foolish { return nil }
 
 // Pure Structure
 type Fuz struct {
@@ -148,10 +160,12 @@ func TestComparison(t *tes.T) {
 	var a0 = []any{}
 	var a1 = []any{Hello, World}
 	var a2 = []any{Hello, Universe}
-	var ShouldBeA0 []any
+	var aNil []any
 
-	ass.True(t, col.CompareValues(ShouldBeA0, a0))
-	ass.False(t, col.CompareValues(a1, ShouldBeA0))
+	ass.True(t, col.CompareValues(aNil, aNil))
+	ass.False(t, col.CompareValues(aNil, a0))
+	ass.False(t, col.CompareValues(a0, aNil))
+	ass.True(t, col.CompareValues(a0, a0))
 
 	ass.False(t, col.CompareValues(a1, a2))
 	ass.True(t, col.CompareValues(a1, a1))
@@ -166,30 +180,35 @@ func TestComparison(t *tes.T) {
 	var m2 = map[any]any{
 		One: True,
 		Two: Hello}
-	var ShouldBeM0 map[any]any
+	var m3 = map[any]any{
+		One: nil,
+		Two: Hello}
+	var mNil map[any]any
 
-	ass.True(t, col.CompareValues(ShouldBeM0, m0))
-	ass.False(t, col.CompareValues(m1, ShouldBeM0))
+	ass.True(t, col.CompareValues(mNil, mNil))
+	ass.False(t, col.CompareValues(mNil, m0))
+	ass.False(t, col.CompareValues(m0, mNil))
+	ass.True(t, col.CompareValues(m0, m0))
 
 	ass.False(t, col.CompareValues(m1, m2))
 	ass.True(t, col.CompareValues(m1, m1))
 	ass.False(t, col.CompareValues(m2, m1))
 	ass.True(t, col.CompareValues(m2, m2))
+	ass.False(t, col.CompareValues(m2, m3))
 
 	// Struct
-	var f1 = &FooBar{1, "one", false}
-	var f2 = &FooBar{1, "one", false}
-	var f3 = &FooBar{2, "two", true}
+	var f0 Foolish
+	var f1 = FooBar(1, "one", nil)
+	var f2 = FooBar(1, "one", nil)
+	var f3 = FooBar(2, "two", nil)
 	var f4 = Fuz{"two"}
 	var f5 = Fuz{"two"}
 	var f6 = Fuz{"three"}
+	ass.True(t, col.CompareValues(f0, f0))
+	ass.False(t, col.CompareValues(f0, f1))
 	ass.True(t, col.CompareValues(f1, f1))
 	ass.True(t, col.CompareValues(f1, f2))
 	ass.False(t, col.CompareValues(f2, f3))
-	ass.True(t, col.CompareValues(*f1, *f1))
-	ass.True(t, col.CompareValues(*f1, *f2))
-	ass.False(t, col.CompareValues(*f2, *f3))
-	ass.False(t, col.CompareValues(*f3, f4))
 	ass.True(t, col.CompareValues(f4, f4))
 	ass.True(t, col.CompareValues(f4, f5))
 	ass.False(t, col.CompareValues(f5, f6))
@@ -395,13 +414,13 @@ func TestRanking(t *tes.T) {
 	var a2 = []any{Hello, Universe}
 	var a3 = []any{Hello, World, Universe}
 	var a4 = []any{Hello, Universe, World}
-	var ShouldBeA0 []any
+	var aNil []any
 
-	ass.Equal(t, 0, col.RankValues(ShouldBeA0, ShouldBeA0))
-	ass.Equal(t, -1, col.RankValues(ShouldBeA0, a1))
-	ass.Equal(t, 0, col.RankValues(a0, ShouldBeA0))
-	ass.Equal(t, 1, col.RankValues(a1, ShouldBeA0))
-	ass.Equal(t, 0, col.RankValues(ShouldBeA0, a0))
+	ass.Equal(t, 0, col.RankValues(aNil, aNil))
+	ass.Equal(t, -1, col.RankValues(aNil, a0))
+	ass.Equal(t, 1, col.RankValues(a0, aNil))
+	ass.Equal(t, 0, col.RankValues(a0, a0))
+	ass.Equal(t, 1, col.RankValues(a1, aNil))
 	ass.Equal(t, -1, col.RankValues(a2, a1))
 	ass.Equal(t, 0, col.RankValues(a2, a2))
 	ass.Equal(t, 1, col.RankValues(a1, a2))
@@ -431,13 +450,12 @@ func TestRanking(t *tes.T) {
 		One:   True,
 		Two:   Universe,
 		Three: World}
-	var ShouldBeM0 map[any]any
+	var mNil map[any]any
 
-	ass.Equal(t, 0, col.RankValues(ShouldBeM0, ShouldBeM0))
-	ass.Equal(t, -1, col.RankValues(ShouldBeM0, m1))
-	ass.Equal(t, 0, col.RankValues(m0, ShouldBeM0))
-	ass.Equal(t, 1, col.RankValues(m1, ShouldBeM0))
-	ass.Equal(t, 0, col.RankValues(ShouldBeM0, m0))
+	ass.Equal(t, 0, col.RankValues(mNil, mNil))
+	ass.Equal(t, -1, col.RankValues(mNil, m0))
+	ass.Equal(t, 1, col.RankValues(m0, mNil))
+	ass.Equal(t, 0, col.RankValues(m0, m0))
 	ass.Equal(t, -1, col.RankValues(m2, m1))
 	ass.Equal(t, 0, col.RankValues(m2, m2))
 	ass.Equal(t, 1, col.RankValues(m1, m2))
@@ -452,9 +470,9 @@ func TestRanking(t *tes.T) {
 	ass.Equal(t, 0, col.RankValues(m1, m1))
 
 	// Struct
-	var f1 = &FooBar{1, "one", true}
-	var f2 = &FooBar{1, "two", true}
-	var f3 = &FooBar{2, "two", false}
+	var f1 = FooBar(1, "one", nil)
+	var f2 = FooBar(1, "two", nil)
+	var f3 = FooBar(2, "two", nil)
 	var f4 = Fuz{"two"}
 	var f5 = Fuz{"two"}
 	var f6 = Fuz{"three"}
@@ -463,16 +481,10 @@ func TestRanking(t *tes.T) {
 	ass.Equal(t, -1, col.RankValues(f2, f3))
 	ass.Equal(t, 1, col.RankValues(f3, f1))
 	ass.Equal(t, 1, col.RankValues(f3, f2))
-	ass.Equal(t, 0, col.RankValues(*f1, *f1))
-	ass.Equal(t, -1, col.RankValues(*f1, *f2))
-	ass.Equal(t, 1, col.RankValues(*f2, *f3))
-	ass.Equal(t, -1, col.RankValues(*f3, *f1))
-	ass.Equal(t, -1, col.RankValues(*f3, *f2))
-	ass.Equal(t, -1, col.RankValues(*f3, f4))
 	ass.Equal(t, 0, col.RankValues(f4, f4))
 	ass.Equal(t, 0, col.RankValues(f4, f5))
 	ass.Equal(t, 1, col.RankValues(f5, f6))
-	ass.Equal(t, -1, col.RankValues(f3, &f4))
+	ass.Equal(t, 1, col.RankValues(f3, &f4))
 	ass.Equal(t, 0, col.RankValues(&f4, &f4))
 	ass.Equal(t, 0, col.RankValues(&f4, &f5))
 	ass.Equal(t, 1, col.RankValues(&f5, &f6))

--- a/v2/collator.go
+++ b/v2/collator.go
@@ -101,7 +101,7 @@ func (v *collator) compareValues(first ref.Value, second ref.Value) bool {
 		case first.IsNil():
 			return second.IsNil()
 		case second.IsNil():
-			return false  // We know that first isn't nil.
+			return false // We know that first isn't nil.
 		default:
 			return v.compareArrays(first, second)
 		}
@@ -110,7 +110,7 @@ func (v *collator) compareValues(first ref.Value, second ref.Value) bool {
 		case first.IsNil():
 			return second.IsNil()
 		case second.IsNil():
-			return false  // We know that first isn't nil.
+			return false // We know that first isn't nil.
 		default:
 			return v.compareMaps(first, second)
 		}
@@ -121,7 +121,7 @@ func (v *collator) compareValues(first ref.Value, second ref.Value) bool {
 		case first.IsNil():
 			return second.IsNil()
 		case second.IsNil():
-			return false  // We know that first isn't nil.
+			return false // We know that first isn't nil.
 		case first.MethodByName("AsArray").IsValid():
 			// The value is a sequence.
 			return v.compareSequences(first, second)
@@ -297,7 +297,7 @@ func (v *collator) rankValues(first ref.Value, second ref.Value) int {
 			// Only the first value is nil.
 			return -1
 		case second.IsNil():
-			return 1  // We know that first isn't nil.
+			return 1 // We know that first isn't nil.
 		default:
 			return v.rankArrays(first, second)
 		}
@@ -310,7 +310,7 @@ func (v *collator) rankValues(first ref.Value, second ref.Value) int {
 			// Only the first value is nil.
 			return -1
 		case second.IsNil():
-			return 1  // We know that first isn't nil.
+			return 1 // We know that first isn't nil.
 		default:
 			return v.rankMaps(first, second)
 		}
@@ -325,7 +325,7 @@ func (v *collator) rankValues(first ref.Value, second ref.Value) int {
 			// Only the first value is nil.
 			return -1
 		case second.IsNil():
-			return 1  // We know that first isn't nil.
+			return 1 // We know that first isn't nil.
 		case first.MethodByName("AsArray").IsValid():
 			// The value is a collection.
 			return v.rankSequences(first, second)

--- a/v2/collator_test.go
+++ b/v2/collator_test.go
@@ -38,12 +38,12 @@ type foobar struct {
 	Baz Foolish
 }
 
-func (v *foobar) GetFoo() int    { return v.foo }
-func (v foobar) GetFoo2() int    { return v.foo }
-func (v *foobar) GetBar() string { return v.bar }
-func (v foobar) GetBar2() string { return v.bar }
-func (v *foobar) GetNil() Foolish    { return nil }
-func (v foobar) GetNil2() Foolish    { return nil }
+func (v *foobar) GetFoo() int     { return v.foo }
+func (v foobar) GetFoo2() int     { return v.foo }
+func (v *foobar) GetBar() string  { return v.bar }
+func (v foobar) GetBar2() string  { return v.bar }
+func (v *foobar) GetNil() Foolish { return nil }
+func (v foobar) GetNil2() Foolish { return nil }
 
 // Pure Structure
 type Fuz struct {

--- a/v2/collator_test.go
+++ b/v2/collator_test.go
@@ -21,19 +21,29 @@ type Boolean bool
 type Integer int
 type String string
 
-// Encapsulated Type
-type FooBar struct {
-	foo int
-	bar string
-	Baz bool
+type Foolish interface {
+	GetFoo() int
+	GetBar() string
+	GetNil() Foolish
 }
 
-func (v *FooBar) GetFoo() int    { return v.foo }
-func (v FooBar) GetFoo2() int    { return v.foo }
-func (v *FooBar) GetBar() string { return v.bar }
-func (v FooBar) GetBar2() string { return v.bar }
-func (v *FooBar) GetNil() any    { return nil }
-func (v FooBar) GetNil2() any    { return nil }
+func FooBar(foo int, bar string, baz Foolish) Foolish {
+	return &foobar{foo, bar, baz}
+}
+
+// Encapsulated Type
+type foobar struct {
+	foo int
+	bar string
+	Baz Foolish
+}
+
+func (v *foobar) GetFoo() int    { return v.foo }
+func (v foobar) GetFoo2() int    { return v.foo }
+func (v *foobar) GetBar() string { return v.bar }
+func (v foobar) GetBar2() string { return v.bar }
+func (v *foobar) GetNil() Foolish    { return nil }
+func (v foobar) GetNil2() Foolish    { return nil }
 
 // Pure Structure
 type Fuz struct {
@@ -150,10 +160,12 @@ func TestComparison(t *tes.T) {
 	var a0 = []any{}
 	var a1 = []any{Hello, World}
 	var a2 = []any{Hello, Universe}
-	var ShouldBeA0 []any
+	var aNil []any
 
-	ass.True(t, col.CompareValues(ShouldBeA0, a0))
-	ass.False(t, col.CompareValues(a1, ShouldBeA0))
+	ass.True(t, col.CompareValues(aNil, aNil))
+	ass.False(t, col.CompareValues(aNil, a0))
+	ass.False(t, col.CompareValues(a0, aNil))
+	ass.True(t, col.CompareValues(a0, a0))
 
 	ass.False(t, col.CompareValues(a1, a2))
 	ass.True(t, col.CompareValues(a1, a1))
@@ -171,10 +183,12 @@ func TestComparison(t *tes.T) {
 	var m3 = map[any]any{
 		One: nil,
 		Two: Hello}
-	var ShouldBeM0 map[any]any
+	var mNil map[any]any
 
-	ass.True(t, col.CompareValues(ShouldBeM0, m0))
-	ass.False(t, col.CompareValues(m1, ShouldBeM0))
+	ass.True(t, col.CompareValues(mNil, mNil))
+	ass.False(t, col.CompareValues(mNil, m0))
+	ass.False(t, col.CompareValues(m0, mNil))
+	ass.True(t, col.CompareValues(m0, m0))
 
 	ass.False(t, col.CompareValues(m1, m2))
 	ass.True(t, col.CompareValues(m1, m1))
@@ -183,19 +197,18 @@ func TestComparison(t *tes.T) {
 	ass.False(t, col.CompareValues(m2, m3))
 
 	// Struct
-	var f1 = &FooBar{1, "one", false}
-	var f2 = &FooBar{1, "one", false}
-	var f3 = &FooBar{2, "two", true}
+	var f0 Foolish
+	var f1 = FooBar(1, "one", nil)
+	var f2 = FooBar(1, "one", nil)
+	var f3 = FooBar(2, "two", nil)
 	var f4 = Fuz{"two"}
 	var f5 = Fuz{"two"}
 	var f6 = Fuz{"three"}
+	ass.True(t, col.CompareValues(f0, f0))
+	ass.False(t, col.CompareValues(f0, f1))
 	ass.True(t, col.CompareValues(f1, f1))
 	ass.True(t, col.CompareValues(f1, f2))
 	ass.False(t, col.CompareValues(f2, f3))
-	ass.True(t, col.CompareValues(*f1, *f1))
-	ass.True(t, col.CompareValues(*f1, *f2))
-	ass.False(t, col.CompareValues(*f2, *f3))
-	ass.False(t, col.CompareValues(*f3, f4))
 	ass.True(t, col.CompareValues(f4, f4))
 	ass.True(t, col.CompareValues(f4, f5))
 	ass.False(t, col.CompareValues(f5, f6))
@@ -401,13 +414,13 @@ func TestRanking(t *tes.T) {
 	var a2 = []any{Hello, Universe}
 	var a3 = []any{Hello, World, Universe}
 	var a4 = []any{Hello, Universe, World}
-	var ShouldBeA0 []any
+	var aNil []any
 
-	ass.Equal(t, 0, col.RankValues(ShouldBeA0, ShouldBeA0))
-	ass.Equal(t, -1, col.RankValues(ShouldBeA0, a1))
-	ass.Equal(t, 0, col.RankValues(a0, ShouldBeA0))
-	ass.Equal(t, 1, col.RankValues(a1, ShouldBeA0))
-	ass.Equal(t, 0, col.RankValues(ShouldBeA0, a0))
+	ass.Equal(t, 0, col.RankValues(aNil, aNil))
+	ass.Equal(t, -1, col.RankValues(aNil, a0))
+	ass.Equal(t, 1, col.RankValues(a0, aNil))
+	ass.Equal(t, 0, col.RankValues(a0, a0))
+	ass.Equal(t, 1, col.RankValues(a1, aNil))
 	ass.Equal(t, -1, col.RankValues(a2, a1))
 	ass.Equal(t, 0, col.RankValues(a2, a2))
 	ass.Equal(t, 1, col.RankValues(a1, a2))
@@ -437,13 +450,12 @@ func TestRanking(t *tes.T) {
 		One:   True,
 		Two:   Universe,
 		Three: World}
-	var ShouldBeM0 map[any]any
+	var mNil map[any]any
 
-	ass.Equal(t, 0, col.RankValues(ShouldBeM0, ShouldBeM0))
-	ass.Equal(t, -1, col.RankValues(ShouldBeM0, m1))
-	ass.Equal(t, 0, col.RankValues(m0, ShouldBeM0))
-	ass.Equal(t, 1, col.RankValues(m1, ShouldBeM0))
-	ass.Equal(t, 0, col.RankValues(ShouldBeM0, m0))
+	ass.Equal(t, 0, col.RankValues(mNil, mNil))
+	ass.Equal(t, -1, col.RankValues(mNil, m0))
+	ass.Equal(t, 1, col.RankValues(m0, mNil))
+	ass.Equal(t, 0, col.RankValues(m0, m0))
 	ass.Equal(t, -1, col.RankValues(m2, m1))
 	ass.Equal(t, 0, col.RankValues(m2, m2))
 	ass.Equal(t, 1, col.RankValues(m1, m2))
@@ -458,9 +470,9 @@ func TestRanking(t *tes.T) {
 	ass.Equal(t, 0, col.RankValues(m1, m1))
 
 	// Struct
-	var f1 = &FooBar{1, "one", true}
-	var f2 = &FooBar{1, "two", true}
-	var f3 = &FooBar{2, "two", false}
+	var f1 = FooBar(1, "one", nil)
+	var f2 = FooBar(1, "two", nil)
+	var f3 = FooBar(2, "two", nil)
 	var f4 = Fuz{"two"}
 	var f5 = Fuz{"two"}
 	var f6 = Fuz{"three"}
@@ -469,16 +481,10 @@ func TestRanking(t *tes.T) {
 	ass.Equal(t, -1, col.RankValues(f2, f3))
 	ass.Equal(t, 1, col.RankValues(f3, f1))
 	ass.Equal(t, 1, col.RankValues(f3, f2))
-	ass.Equal(t, 0, col.RankValues(*f1, *f1))
-	ass.Equal(t, -1, col.RankValues(*f1, *f2))
-	ass.Equal(t, 1, col.RankValues(*f2, *f3))
-	ass.Equal(t, -1, col.RankValues(*f3, *f1))
-	ass.Equal(t, -1, col.RankValues(*f3, *f2))
-	ass.Equal(t, -1, col.RankValues(*f3, f4))
 	ass.Equal(t, 0, col.RankValues(f4, f4))
 	ass.Equal(t, 0, col.RankValues(f4, f5))
 	ass.Equal(t, 1, col.RankValues(f5, f6))
-	ass.Equal(t, -1, col.RankValues(f3, &f4))
+	ass.Equal(t, 1, col.RankValues(f3, &f4))
 	ass.Equal(t, 0, col.RankValues(&f4, &f4))
 	ass.Equal(t, 0, col.RankValues(&f4, &f5))
 	ass.Equal(t, 1, col.RankValues(&f5, &f6))


### PR DESCRIPTION
This pull request addresses issue #26: 

A summary of the changes included in this pull request:
 1. Added checks for nil values for interfaces, pointers, maps, arrays and slices in both the `collator.compareValues()` and `collator.rankValues()` methods for bug fix release v1.10.1.
 2. Added checks for nil values for interfaces, pointers, maps, arrays and slices in both the `collator.compareValues()` and `collator.rankValues()` methods for bug fix release v2.0.1 

To be reviewed by: @derknorton
