### PR TITLE
Changed tabs to 4 spaces in all output for consistency.

### DIFF
--- a/v2/collator.go
+++ b/v2/collator.go
@@ -142,7 +142,7 @@ func (v *collator) compareValues(first ref.Value, second ref.Value) bool {
 
 	default:
 		panic(fmt.Sprintf(
-			"Attempted to compare:\n\tfirst: %v\n\ttype: %v\n\tkind: %v\nand\n\tsecond: %v\n\ttype: %v\n\tkind: %v\n",
+			"Attempted to compare:\n    first: %v\n    type: %v\n    kind: %v\nand\n    second: %v\n    type: %v\n    kind: %v\n",
 			first.Interface(),
 			first.Type(),
 			first.Kind(),
@@ -351,7 +351,7 @@ func (v *collator) rankValues(first ref.Value, second ref.Value) int {
 
 	default:
 		panic(fmt.Sprintf(
-			"Attempted to rank:\n\tfirst: %v\n\ttype: %v\n\tkind: %v\nand\n\tsecond: %v\n\ttype: %v\n\tkind: %v\n",
+			"Attempted to rank:\n    first: %v\n    type: %v\n    kind: %v\nand\n    second: %v\n    type: %v\n    kind: %v\n",
 			first.Interface(),
 			first.Type(),
 			first.Kind(),

--- a/v2/formatter.go
+++ b/v2/formatter.go
@@ -82,7 +82,7 @@ func (v *formatter) AppendNewline() {
 	var separator = "\n"
 	var levels = v.depth + v.indentation
 	for level := 0; level < levels; level++ {
-		separator += "\t"
+		separator += "    "
 	}
 	v.result.WriteString(separator)
 }
@@ -135,7 +135,7 @@ func (v *formatter) formatValue(value ref.Value) {
 			v.formatNil(value)
 		} else {
 			panic(fmt.Sprintf(
-				"Attempted to format:\n\tvalue: %v\n\ttype: %v\n\tkind: %v\n",
+				"Attempted to format:\n    value: %v\n    type: %v\n    kind: %v\n",
 				value.Interface(),
 				value.Type(),
 				value.Kind()))

--- a/v2/formatter_test.go
+++ b/v2/formatter_test.go
@@ -261,7 +261,7 @@ func TestFormatInvalidType(t *tes.T) {
 	var s struct{}
 	defer func() {
 		if e := recover(); e != nil {
-			ass.Equal(t, "Attempted to format:\n\tvalue: {}\n\ttype: struct {}\n\tkind: struct\n", e)
+			ass.Equal(t, "Attempted to format:\n    value: {}\n    type: struct {}\n    kind: struct\n", e)
 		} else {
 			ass.Fail(t, "Test should result in recovered panic.")
 		}

--- a/v2/stack_test.go
+++ b/v2/stack_test.go
@@ -21,7 +21,7 @@ func TestStackWithSmallCapacity(t *tes.T) {
 	stack.AddValue(1)
 	defer func() {
 		if e := recover(); e != nil {
-			ass.Equal(t, "Attempted to add a value onto a stack that has reached its capacity: 1\nvalue: 2\nstack: [\n\t1\n](stack)\n", e)
+			ass.Equal(t, "Attempted to add a value onto a stack that has reached its capacity: 1\nvalue: 2\nstack: [\n    1\n](stack)\n", e)
 		} else {
 			ass.Fail(t, "Test should result in recovered panic.")
 		}


### PR DESCRIPTION
This pull request addresses issue #28: 

A summary of the changes included in this pull request:
 1. All tabs in formatting and error output have been changed to 4 spaces.

To be reviewed by: @derknorton
