### PR TITLE
Simplified the formatter interface to just focus on collections and a…

### DIFF
--- a/v2/abstractions.go
+++ b/v2/abstractions.go
@@ -176,16 +176,6 @@ type Ratcheted[V Value] interface {
 	GetNext() V
 }
 
-// This interface defines the methods supported by all canonical agents that can
-// format any value in a standard way.
-type Canonical interface {
-	GetIndentation() int
-	FormatValue(value Value)
-	AppendString(s string)
-	AppendNewline()
-	GetResult() string
-}
-
 // This interface defines the methods supported by all discerning agent types
 // that can compare and rank two values.
 type Discerning interface {
@@ -286,11 +276,6 @@ type StackLike[V Value] interface {
 // This interface defines the methods supported by all iterator-like types.
 type IteratorLike[V Value] interface {
 	Ratcheted[V]
-}
-
-// This interface defines the methods supported by all sorter-like types.
-type FormatterLike interface {
-	Canonical
 }
 
 // This interface defines the methods supported by all collator-like types.

--- a/v2/array.go
+++ b/v2/array.go
@@ -89,7 +89,7 @@ func (v Array[V]) SetValues(index int, values Sequential[V]) {
 
 // This method is used by Go to generate a string from an array.
 func (v Array[V]) String() string {
-	return FormatValue(v)
+	return FormatCollection(v)
 }
 
 // This method normalizes an index to match the Go (zero based) indexing. The

--- a/v2/catalog.go
+++ b/v2/catalog.go
@@ -49,7 +49,7 @@ func (v *association[K, V]) SetValue(value V) {
 
 // This method returns a canonical string for this association.
 func (v *association[K, V]) String() string {
-	return FormatValue(v)
+	return FormatAssociation(v)
 }
 
 // CATALOG IMPLEMENTATION
@@ -241,5 +241,5 @@ func (v *catalog[K, V]) ShuffleValues() {
 // GO INTERFACE
 
 func (v *catalog[K, V]) String() string {
-	return FormatValue(v)
+	return FormatCollection(v)
 }

--- a/v2/collections.cdsn
+++ b/v2/collections.cdsn
@@ -1,12 +1,12 @@
 !>
-    A formal definition of a document containing a collection using Bali Wirth
-    Syntax Notation™ (BWSN):
-        <https://github.com/bali-nebula/specifications/blob/main/bwsn.bwsn>
+    A formal definition of a document containing a collection using Crater Dog
+    Syntax Notation™ (CDSN):
+        <https://github.com/craterdog/go-cdsn-validation/wiki>
 
     The token names are identified by all CAPITAL characters and the rule names
     are identified by lowerCamelCase characters. The token and rule definitions
     have been alphabetized to make it easier to locate specific definitions.
-    The starting rule is "$document".
+    The starting rule is "$source".
 <!
 
 $BASE10: "0".."9"
@@ -62,11 +62,11 @@ $associations:
 
 $collection: "[" (values | associations) "]" "(" CONTEXT ")"
 
-$document: collection EOF  ! EOF is the end-of-file marker.
-
 $key: primitive
 
 $primitive: BOOLEAN | COMPLEX | FLOAT | INTEGER | NIL | RUNE | STRING
+
+$source: collection EOF  ! EOF is the end-of-file marker.
 
 $value: primitive | collection
 

--- a/v2/formatter_test.go
+++ b/v2/formatter_test.go
@@ -37,69 +37,30 @@ var v6 rune = '☺'
 var v7 string = "Hello World!"
 var v8 = []int{1, 2, 3}
 
-func TestFormatWithIndentation(t *tes.T) {
-	var formatter = col.Formatter(1)
-	ass.Equal(t, 1, formatter.GetIndentation())
-}
-
-func TestFormatPrimitives(t *tes.T) {
-	var s0 = col.FormatValue(nil)
-	ass.Equal(t, "<nil>", s0)
-	fmt.Println("\nNil: " + s0)
-
-	var s1 = col.FormatValue(v1)
-	ass.Equal(t, "true", s1)
-	fmt.Println("\nBoolean: " + s1)
-
-	var s2 = col.FormatValue(v2)
-	ass.Equal(t, "0xa", s2)
-	fmt.Println("\nUnsigned: " + s2)
-
-	var s3 = col.FormatValue(v3)
-	ass.Equal(t, "42", s3)
-	fmt.Println("\nInteger: " + s3)
-
-	var s4 = col.FormatValue(v4)
-	ass.Equal(t, "0.125", s4)
-	fmt.Println("\nFloat: " + s4)
-
-	var s5 = col.FormatValue(v5)
-	ass.Equal(t, "(1.0+1.0i)", s5)
-	fmt.Println("\nComplex: " + s5)
-
-	var s6 = col.FormatValue(v6)
-	ass.Equal(t, "'☺'", s6)
-	fmt.Println("\nRune: " + s6)
-
-	var s7 = col.FormatValue(v7)
-	ass.Equal(t, "\"Hello World!\"", s7)
-	fmt.Println("\nString: " + s7)
-}
-
 func TestFormatEmptyArray(t *tes.T) {
 	var array = []any{}
-	var s = col.FormatValue(array)
+	var s = col.FormatCollection(array)
 	ass.Equal(t, "[ ](array)", s)
 	fmt.Println("\nEmpty Array: " + s)
 }
 
 func TestFormatArrayOfAny(t *tes.T) {
 	var array = []any{v1, v2, v3, v4, v5, v6, v7, v8}
-	var s = col.FormatValue(array)
+	var s = col.FormatCollection(array)
 	ass.Equal(t, "(array)", s[len(s)-7:])
 	fmt.Println("\nArray of Any: " + s)
 }
 
 func TestFormatArrayOfIntegers(t *tes.T) {
 	var array = []int{1, 2, 3, 4}
-	var s = col.FormatValue(array)
+	var s = col.FormatCollection(array)
 	ass.Equal(t, "(array)", s[len(s)-7:])
 	fmt.Println("\nArray of Integers: " + s)
 }
 
 func TestFormatEmptyMap(t *tes.T) {
 	var mapp = map[any]any{}
-	var s = col.FormatValue(mapp)
+	var s = col.FormatCollection(mapp)
 	ass.Equal(t, "[:](map)", s)
 	fmt.Println("\nEmpty Map: " + s)
 }
@@ -114,7 +75,7 @@ func TestFormatMapOfAnyToAny(t *tes.T) {
 		k6: v6,
 		k7: v7,
 		k8: v8}
-	var s = col.FormatValue(mapp)
+	var s = col.FormatCollection(mapp)
 	ass.Equal(t, "(map)", s[len(s)-5:])
 	fmt.Println("\nMap of Any to Any: " + s)
 }
@@ -124,21 +85,21 @@ func TestFormatMapOfStringToInteger(t *tes.T) {
 		"first":  1,
 		"second": 2,
 		"third":  3}
-	var s = col.FormatValue(mapp)
+	var s = col.FormatCollection(mapp)
 	ass.Equal(t, "(map)", s[len(s)-5:])
 	fmt.Println("\nMap of String to Integer: " + s)
 }
 
 func TestFormatEmptyList(t *tes.T) {
 	var list = col.List[any]()
-	var s = col.FormatValue(list)
+	var s = col.FormatCollection(list)
 	ass.Equal(t, "[ ](list)", s)
 	fmt.Println("\nEmpty List: " + s)
 }
 
 func TestFormatListOfAny(t *tes.T) {
 	var list = col.ListFromArray[any]([]any{v1, v2, v3, v4, v5, v6, v7, v8})
-	var s = col.FormatValue(list)
+	var s = col.FormatCollection(list)
 	ass.Equal(t, s, fmt.Sprintf("%s", list))
 	ass.Equal(t, "(list)", s[len(s)-6:])
 	fmt.Println("\nList of Any: " + s)
@@ -146,13 +107,13 @@ func TestFormatListOfAny(t *tes.T) {
 
 func TestFormatListOfBoolean(t *tes.T) {
 	var list = col.ListFromArray[bool]([]bool{k1, v1})
-	var s = col.FormatValue(list)
+	var s = col.FormatCollection(list)
 	fmt.Println("\nList of Boolean: " + s)
 }
 
 func TestFormatSetOfAny(t *tes.T) {
 	var set = col.SetFromArray[any]([]any{v1, v2, v3, v4, v5, v6, v7, v8})
-	var s = col.FormatValue(set)
+	var s = col.FormatCollection(set)
 	ass.Equal(t, s, fmt.Sprintf("%s", set))
 	ass.Equal(t, "(set)", s[len(s)-5:])
 	fmt.Println("\nSet of Any: " + s)
@@ -162,7 +123,7 @@ func TestFormatSetOfSet(t *tes.T) {
 	var set1 = col.SetFromArray[any]([]any{v1, v2, v3, v4, v5, v6, v7, v8})
 	var set2 = col.SetFromArray[any]([]any{k1, k2, k3, k4, k5, k6, k7, k8})
 	var set = col.SetFromArray[col.SetLike[any]]([]col.SetLike[any]{set1, set2})
-	var s = col.FormatValue(set)
+	var s = col.FormatCollection(set)
 	fmt.Println("\nSet of Set: " + s)
 }
 
@@ -175,7 +136,7 @@ func TestFormatStackOfAny(t *tes.T) {
 	stack.AddValue(v5)
 	stack.AddValue(v6)
 	stack.AddValue(v7)
-	var s = col.FormatValue(stack)
+	var s = col.FormatCollection(stack)
 	ass.Equal(t, s, fmt.Sprintf("%s", stack))
 	ass.Equal(t, "(stack)", s[len(s)-7:])
 	fmt.Println("\nStack: " + s)
@@ -190,28 +151,15 @@ func TestFormatQueueOfAny(t *tes.T) {
 	queue.AddValue(v5)
 	queue.AddValue(v6)
 	queue.AddValue(v7)
-	var s = col.FormatValue(queue)
+	var s = col.FormatCollection(queue)
 	ass.Equal(t, s, fmt.Sprintf("%s", queue))
 	ass.Equal(t, "(queue)", s[len(s)-7:])
 	fmt.Println("\nQueue: " + s)
 }
 
-func TestFormatAssociationOfAnyToAny(t *tes.T) {
-	var association = col.Association[any, any]("foo", 5)
-	var s = col.FormatValue(association)
-	ass.Equal(t, s, fmt.Sprintf("%s", association))
-	fmt.Println("\nAssociation of Any to Any: " + s)
-}
-
-func TestFormatAssociationOfStringToInteger(t *tes.T) {
-	var association = col.Association[string, int]("bar", 42)
-	var s = col.FormatValue(association)
-	fmt.Println("\nAssociation of String to Integer: " + s)
-}
-
 func TestFormatEmptyCatalog(t *tes.T) {
 	var catalog = col.Catalog[any, any]()
-	var s = col.FormatValue(catalog)
+	var s = col.FormatCollection(catalog)
 	ass.Equal(t, "[:](catalog)", s)
 	fmt.Println("\nEmpty Catalog: " + s)
 }
@@ -225,7 +173,7 @@ func TestFormatCatalogOfAnyToAny(t *tes.T) {
 	catalog.SetValue(k5, v5)
 	catalog.SetValue(k6, v6)
 	catalog.SetValue(k7, v7)
-	var s = col.FormatValue(catalog)
+	var s = col.FormatCollection(catalog)
 	ass.Equal(t, s, fmt.Sprintf("%s", catalog))
 	ass.Equal(t, "(catalog)", s[len(s)-9:])
 	fmt.Println("\nCatalog: " + s)
@@ -240,7 +188,7 @@ func TestFormatCatalogOfStringToAny(t *tes.T) {
 	catalog.SetValue("key5", v5)
 	catalog.SetValue("key6", v6)
 	catalog.SetValue("key7", v7)
-	var s = col.FormatValue(catalog)
+	var s = col.FormatCollection(catalog)
 	fmt.Println("\nCatalog of String to Any: " + s)
 }
 
@@ -253,7 +201,7 @@ func TestFormatCatalogOfStringToInteger(t *tes.T) {
 	catalog.SetValue("key5", 5)
 	catalog.SetValue("key6", 6)
 	catalog.SetValue("key7", 7)
-	var s = col.FormatValue(catalog)
+	var s = col.FormatCollection(catalog)
 	fmt.Println("\nCatalog of String to Integer: " + s)
 }
 
@@ -266,5 +214,5 @@ func TestFormatInvalidType(t *tes.T) {
 			ass.Fail(t, "Test should result in recovered panic.")
 		}
 	}()
-	col.FormatValue(s) // This should panic.
+	col.FormatCollection(s) // This should panic.
 }

--- a/v2/grammar.go
+++ b/v2/grammar.go
@@ -47,9 +47,9 @@ var grammar = map[string]string{
     EOL <association EOL> |
     ":"  ! No associations.`,
 	"$collection": `"[" (values | associations) "]" "(" CONTEXT ")"`,
-	"$document":  `collection EOF  ! EOF is the end-of-file marker.`,
 	"$key":       `primitive`,
 	"$primitive": `BOOLEAN | COMPLEX | FLOAT | INTEGER | NIL | RUNE | STRING`,
+	"$source":  `collection EOF  ! EOF is the end-of-file marker.`,
 	"$value":     `primitive | collection`,
 	"$values": `
     value {"," value} |
@@ -58,14 +58,14 @@ var grammar = map[string]string{
 }
 
 const header = `!>
-    A formal definition of a document containing a collection using Bali Wirth
-    Syntax Notation™ (BWSN):
-        <https://github.com/bali-nebula/specifications/blob/main/bwsn.bwsn>
+    A formal definition of a document containing a collection using Crater Dog
+    Syntax Notation™ (CDSN):
+        <https://github.com/craterdog/go-cdsn-validation/wiki>
 
     The token names are identified by all CAPITAL characters and the rule names
     are identified by lowerCamelCase characters. The token and rule definitions
     have been alphabetized to make it easier to locate specific definitions.
-    The starting rule is "$document".
+    The starting rule is "$source".
 <!
 
 `

--- a/v2/grammar_test.go
+++ b/v2/grammar_test.go
@@ -17,10 +17,10 @@ import (
 	tes "testing"
 )
 
-const cdcn = "./cdcn.bwsn"
+const filename = "./collections.cdsn"
 
 func TestGenerateGrammar(t *tes.T) {
-	var err = osx.WriteFile(cdcn, []byte(bal.FormatGrammar()), 0644)
+	var err = osx.WriteFile(filename, []byte(bal.FormatGrammar()), 0644)
 	if err != nil {
 		var message = fmt.Sprintf("Could not create the bwsn file: %v.", err)
 		panic(message)

--- a/v2/list.go
+++ b/v2/list.go
@@ -236,7 +236,7 @@ func (v *list[V]) ShuffleValues() {
 // GO INTERFACE
 
 func (v *list[V]) String() string {
-	return FormatValue(v)
+	return FormatCollection(v)
 }
 
 // PRIVATE INTERFACE

--- a/v2/map.go
+++ b/v2/map.go
@@ -131,5 +131,5 @@ func (v Map[K, V]) RemoveAll() {
 // GO INTERFACE
 
 func (v Map[K, V]) String() string {
-	return FormatValue(v)
+	return FormatCollection(v)
 }

--- a/v2/queue.go
+++ b/v2/queue.go
@@ -284,5 +284,5 @@ func (v *queue[V]) CloseQueue() {
 // GO INTERFACE
 
 func (v *queue[V]) String() string {
-	return FormatValue(v)
+	return FormatCollection(v)
 }

--- a/v2/set.go
+++ b/v2/set.go
@@ -202,7 +202,7 @@ func (v *set[V]) RemoveAll() {
 // GO INTERFACE
 
 func (v *set[V]) String() string {
-	return FormatValue(v)
+	return FormatCollection(v)
 }
 
 // PRIVATE INTERFACE

--- a/v2/stack.go
+++ b/v2/stack.go
@@ -101,5 +101,5 @@ func (v *stack[V]) RemoveAll() {
 // GO INTERFACE
 
 func (v *stack[V]) String() string {
-	return FormatValue(v)
+	return FormatCollection(v)
 }


### PR DESCRIPTION
…ssociations.

This pull request addresses issue #33: 

A summary of the changes included in this pull request:
 1. The formatter interface was removed from the abstractions.
 2. The exported formatting functions are focused on collections and associations.

To be reviewed by: @derknorton
