### PR TITLE
39 add fromarrayarray and fromstringstring constructors to each collection type

### DIFF
--- a/v3/array.go
+++ b/v3/array.go
@@ -48,13 +48,13 @@ func Array[V Value]() *arrayClass_[V] {
 
 // CLASS CONSTRUCTORS
 
-// This public class constructor creates a new Array from the specified
-// Go array of values.
-func (c *arrayClass_[V]) FromArray(array []V) ArrayLike[V] {
-	var length = len(array)
-	var duplicate = make([]V, length)
-	copy(duplicate, array)
-	return array_[V](duplicate)
+// This public class constructor creates a new Array from the specified Go array
+// of values.
+func (c *arrayClass_[V]) FromArray(values []V) ArrayLike[V] {
+	var length = len(values)
+	var array = make([]V, length)
+	copy(array, values)
+	return array_[V](array)
 }
 
 // This public class constructor creates a new Array of the specified size.

--- a/v3/array.go
+++ b/v3/array.go
@@ -57,6 +57,24 @@ func (c *arrayClass_[V]) FromArray(values []V) ArrayLike[V] {
 	return array_[V](array)
 }
 
+// This public class constructor creates a new Array from the specified string
+// containing the CDCN definition for the Array.
+func (c *arrayClass_[V]) FromString(source string) ArrayLike[V] {
+	// First we parse it as a collection of any type value.
+	var collection = Parser().ParseCollection([]byte(source)).(Sequential[Value])
+
+	// Then we convert it to an Array of type V.
+	var array = c.WithSize(collection.GetSize())
+	var index int
+	var iterator = collection.GetIterator()
+	for iterator.HasNext() {
+		index++
+		var value = iterator.GetNext().(V)
+		array.SetValue(index, value)
+	}
+	return array
+}
+
 // This public class constructor creates a new Array of the specified size.
 func (c *arrayClass_[V]) WithSize(size int) ArrayLike[V] {
 	var array = make([]V, size) // All values initialized to zero.

--- a/v3/array_test.go
+++ b/v3/array_test.go
@@ -16,6 +16,11 @@ import (
 	tes "testing"
 )
 
+func TestArrayConstructor(t *tes.T) {
+	var _ = col.Array[int64]().FromString("[ ](Array)\n")
+	var _ = col.Array[int64]().FromString("[1, 2, 3](Array)\n")
+}
+
 func TestEmptyArray(t *tes.T) {
 	var array = col.Array[string]().WithSize(0)
 	ass.True(t, array.IsEmpty())

--- a/v3/catalog.go
+++ b/v3/catalog.go
@@ -82,6 +82,24 @@ func (c *catalogClass_[K, V]) FromSequence(
 	return catalog
 }
 
+// This public class constructor creates a new Catalog from the specified string
+// containing the CDCN definition for the Catalog.
+func (c *catalogClass_[K, V]) FromString(source string) CatalogLike[K, V] {
+	// First we parse it as a collection of any type value.
+	var collection = Parser().ParseCollection([]byte(source)).(Sequential[Binding[Key, Value]])
+
+	// Then we convert it to a Catalog of type Binding[K, V].
+	var catalog = c.Empty()
+	var iterator = collection.GetIterator()
+	for iterator.HasNext() {
+		var association = iterator.GetNext()
+		var key = association.GetKey().(K)
+		var value = association.GetValue().(V)
+		catalog.SetValue(key, value)
+	}
+	return catalog
+}
+
 // CLASS FUNCTIONS
 
 // This public class function returns a new Catalog containing only the

--- a/v3/catalog.go
+++ b/v3/catalog.go
@@ -56,9 +56,21 @@ func (c *catalogClass_[K, V]) Empty() CatalogLike[K, V] {
 	return catalog
 }
 
+// This public class constructor creates a new Catalog from the specified Go
+// array of values.
+func (c *catalogClass_[K, V]) FromArray(
+	associations []Binding[K, V],
+) CatalogLike[K, V] {
+	var array = Array[Binding[K, V]]().FromArray(associations)
+	var catalog = c.FromSequence(array)
+	return catalog
+}
+
 // This public class constructor creates a new Catalog from the specified
 // sequence of associations.
-func (c *catalogClass_[K, V]) FromSequence(associations Sequential[Binding[K, V]]) CatalogLike[K, V] {
+func (c *catalogClass_[K, V]) FromSequence(
+	associations Sequential[Binding[K, V]],
+) CatalogLike[K, V] {
 	var catalog = c.Empty()
 	var iterator = associations.GetIterator()
 	for iterator.HasNext() {
@@ -76,7 +88,10 @@ func (c *catalogClass_[K, V]) FromSequence(associations Sequential[Binding[K, V]
 // associations that are in the specified Catalog that have the specified keys.
 // The associations in the resulting Catalog will be in the same order as the
 // specified keys.
-func (c *catalogClass_[K, V]) Extract(catalog CatalogLike[K, V], keys Sequential[K]) CatalogLike[K, V] {
+func (c *catalogClass_[K, V]) Extract(
+	catalog CatalogLike[K, V],
+	keys Sequential[K],
+) CatalogLike[K, V] {
 	var result = c.Empty()
 	var iterator = keys.GetIterator()
 	for iterator.HasNext() {
@@ -91,7 +106,10 @@ func (c *catalogClass_[K, V]) Extract(catalog CatalogLike[K, V], keys Sequential
 // associations that are in the specified catalogs in the order that they appear
 // in each Catalog.  If a key is present in both catalogs, the value of the key
 // from the second Catalog takes precedence.
-func (c *catalogClass_[K, V]) Merge(first, second CatalogLike[K, V]) CatalogLike[K, V] {
+func (c *catalogClass_[K, V]) Merge(
+	first CatalogLike[K, V],
+	second CatalogLike[K, V],
+) CatalogLike[K, V] {
 	var catalog = c.FromSequence(first)
 	var iterator = second.GetIterator()
 	for iterator.HasNext() {

--- a/v3/catalog_test.go
+++ b/v3/catalog_test.go
@@ -121,6 +121,12 @@ func TestCatalogsWithExtract(t *tes.T) {
 	catalog3.SetValue(association1.GetKey(), association1.GetValue())
 	catalog3.SetValue(association3.GetKey(), association3.GetValue())
 	ass.True(t, col.Collator().CompareValues(catalog2, catalog3))
+	var catalog4 = Catalog.FromArray([]col.Binding[string, int]{
+		association1,
+		association2,
+		association3,
+	})
+	ass.True(t, col.Collator().CompareValues(catalog1, catalog4))
 }
 
 func TestCatalogsWithEmptyCatalogs(t *tes.T) {

--- a/v3/catalog_test.go
+++ b/v3/catalog_test.go
@@ -16,6 +16,11 @@ import (
 	tes "testing"
 )
 
+func TestCatalogConstructor(t *tes.T) {
+	var _ = col.Catalog[rune, int64]().FromString("[:](Catalog)\n")
+	var _ = col.Catalog[rune, int64]().FromString("['a': 1, 'b': 2, 'c': 3](Catalog)\n")
+}
+
 func TestCatalogsWithStringsAndIntegers(t *tes.T) {
 	var Array = col.Array[string]()
 	var keys = Array.FromArray([]string{"foo", "bar"})

--- a/v3/list.go
+++ b/v3/list.go
@@ -56,6 +56,14 @@ func (c *listClass_[V]) Empty() ListLike[V] {
 	return list
 }
 
+// This public class constructor creates a new List from the specified Go array
+// of values.
+func (c *listClass_[V]) FromArray(values []V) ListLike[V] {
+	var array = Array[V]().FromArray(values)
+	var list = c.FromSequence(array)
+	return list
+}
+
 // This public class constructor creates a new List from the specified sequence
 // of values.  The List uses the default compare function.
 func (c *listClass_[V]) FromSequence(values Sequential[V]) ListLike[V] {

--- a/v3/list.go
+++ b/v3/list.go
@@ -76,10 +76,26 @@ func (c *listClass_[V]) FromSequence(values Sequential[V]) ListLike[V] {
 	return list
 }
 
+// This public class constructor creates a new List from the specified string
+// containing the CDCN definition for the List.
+func (c *listClass_[V]) FromString(source string) ListLike[V] {
+	// First we parse it as a collection of any type value.
+	var collection = Parser().ParseCollection([]byte(source)).(Sequential[Value])
+
+	// Then we convert it to a List of type V.
+	var list = c.Empty()
+	var iterator = collection.GetIterator()
+	for iterator.HasNext() {
+		var value = iterator.GetNext().(V)
+		list.AppendValue(value)
+	}
+	return list
+}
+
 // This public class constructor creates a new empty List that uses the
 // specified comparing function.
 func (c *listClass_[V]) WithComparer(compare ComparingFunction) ListLike[V] {
-	var Array = Array[V]() // Retrieve the array namespace.
+	var Array = Array[V]() // Retrieve the List namespace.
 	var values = Array.WithSize(0)
 	var list = &list_[V]{
 		compare: compare,
@@ -119,13 +135,13 @@ type list_[V Value] struct {
 
 // Accessible Interface
 
-// This public class method retrieves from this array the value that is
+// This public class method retrieves from this List the value that is
 // associated with the specified index.
 func (v *list_[V]) GetValue(index int) V {
 	return v.values.GetValue(index)
 }
 
-// This public class method retrieves from this array all values from the first
+// This public class method retrieves from this List all values from the first
 // index through the last index (inclusive).
 func (v *list_[V]) GetValues(first int, last int) Sequential[V] {
 	return v.values.GetValues(first, last)

--- a/v3/list_test.go
+++ b/v3/list_test.go
@@ -53,6 +53,7 @@ func TestListsWithStrings(t *tes.T) {
 	list.AppendValues(barbaz)                     //       ["foo", "bar", "baz"]
 	ass.Equal(t, 3, list.GetSize())               //       ["foo", "bar", "baz"]
 	ass.Equal(t, "foo", string(list.GetValue(1))) //       ["foo", "bar", "baz"]
+	ass.True(t, Collator.CompareValues(List.FromArray(list.AsArray()), list))
 	ass.Equal(t, barbaz.AsArray(), list.GetValues(2, 3).AsArray())
 	ass.Equal(t, foo.AsArray(), list.GetValues(1, 1).AsArray())
 	var list2 = List.FromSequence(list)

--- a/v3/list_test.go
+++ b/v3/list_test.go
@@ -16,6 +16,11 @@ import (
 	tes "testing"
 )
 
+func TestListConstructor(t *tes.T) {
+	var _ = col.List[int64]().FromString("[ ](List)\n")
+	var _ = col.List[int64]().FromString("[1, 2, 3](List)\n")
+}
+
 func TestListsWithStrings(t *tes.T) {
 	var Collator = col.Collator()
 	var Array = col.Array[string]()

--- a/v3/map.go
+++ b/v3/map.go
@@ -52,6 +52,11 @@ func Map[K comparable, V Value]() *mapClass_[K, V] {
 
 // CLASS CONSTRUCTORS
 
+// This public class constructor creates a new empty Map.
+func (c *mapClass_[K, V]) Empty() MapLike[K, V] {
+	return map_[K, V](map[K]V{})
+}
+
 // This public class constructor creates a new Map from the specified
 // Go array of associations.
 func (c *mapClass_[K, V]) FromArray(associations []Binding[K, V]) MapLike[K, V] {
@@ -74,6 +79,24 @@ func (c *mapClass_[K, V]) FromMap(associations map[K]V) MapLike[K, V] {
 		duplicate[key] = value
 	}
 	return map_[K, V](duplicate)
+}
+
+// This public class constructor creates a new Map from the specified string
+// containing the CDCN definition for the Map.
+func (c *mapClass_[K, V]) FromString(source string) MapLike[K, V] {
+	// First we parse it as a collection of any type value.
+	var collection = Parser().ParseCollection([]byte(source)).(Sequential[Binding[Key, Value]])
+
+	// Then we convert it to a Map of type Binding[K, V].
+	var map_ = c.Empty()
+	var iterator = collection.GetIterator()
+	for iterator.HasNext() {
+		var association = iterator.GetNext()
+		var key = association.GetKey().(K)
+		var value = association.GetValue().(V)
+		map_.SetValue(key, value)
+	}
+	return map_
 }
 
 // CLASS TYPE

--- a/v3/map_test.go
+++ b/v3/map_test.go
@@ -16,6 +16,11 @@ import (
 	tes "testing"
 )
 
+func TestMapConstructor(t *tes.T) {
+	var _ = col.Map[rune, int64]().FromString("[:](Map)\n")
+	var _ = col.Map[rune, int64]().FromString("['a': 1, 'b': 2, 'c': 3](Map)\n")
+}
+
 func TestEmptyMaps(t *tes.T) {
 	var Map = col.Map[string, int]()
 	var m = Map.FromMap(map[string]int{})

--- a/v3/map_test.go
+++ b/v3/map_test.go
@@ -39,7 +39,15 @@ func TestMapsWithStringsAndIntegers(t *tes.T) {
 	var association2 = Association.FromPair("bar", 2)
 	var association3 = Association.FromPair("baz", 3)
 	var Map = col.Map[string, int]()
-	var m = Map.FromMap(map[string]int{})
+	var m = Map.FromArray([]col.Binding[string, int]{
+		association1,
+		association2,
+		association3,
+	})
+	ass.Equal(t, 1, int(m.GetValue("foo")))
+	ass.Equal(t, 2, int(m.GetValue("bar")))
+	ass.Equal(t, 3, int(m.GetValue("baz")))
+	m = Map.FromMap(map[string]int{})
 	m.SetValue(association1.GetKey(), association1.GetValue())
 	ass.False(t, m.IsEmpty())
 	ass.Equal(t, 1, m.GetSize())

--- a/v3/queue.go
+++ b/v3/queue.go
@@ -84,6 +84,22 @@ func (c *queueClass_[V]) FromSequence(values Sequential[V]) QueueLike[V] {
 	return queue
 }
 
+// This public class constructor creates a new Queue from the specified string
+// containing the CDCN definition for the Queue.
+func (c *queueClass_[V]) FromString(source string) QueueLike[V] {
+	// First we parse it as a collection of any type value.
+	var collection = Parser().ParseCollection([]byte(source)).(Sequential[Value])
+
+	// Then we convert it to a Queue of type V.
+	var queue = c.Empty()
+	var iterator = collection.GetIterator()
+	for iterator.HasNext() {
+		var value = iterator.GetNext().(V)
+		queue.AddValue(value)
+	}
+	return queue
+}
+
 // This public class constructor creates a new empty Queue with the specified
 // capacity.
 func (c *queueClass_[V]) WithCapacity(capacity int) QueueLike[V] {

--- a/v3/queue.go
+++ b/v3/queue.go
@@ -64,6 +64,14 @@ func (c *queueClass_[V]) Empty() QueueLike[V] {
 	return queue
 }
 
+// This public class constructor creates a new Queue from the specified Go array
+// of values.
+func (c *queueClass_[V]) FromArray(values []V) QueueLike[V] {
+	var array = Array[V]().FromArray(values)
+	var queue = c.FromSequence(array)
+	return queue
+}
+
 // This public class constructor creates a new Queue from the specified
 // sequence of values. The Queue uses the default capacity which is 16.
 func (c *queueClass_[V]) FromSequence(values Sequential[V]) QueueLike[V] {

--- a/v3/queue_test.go
+++ b/v3/queue_test.go
@@ -17,6 +17,11 @@ import (
 	tes "testing"
 )
 
+func TestQueueConstructor(t *tes.T) {
+	var _ = col.Queue[int64]().FromString("[ ](Queue)\n")
+	var _ = col.Queue[int64]().FromString("[1, 2, 3](Queue)\n")
+}
+
 func TestQueueConstructors(t *tes.T) {
 	var Queue = col.Queue[int]()
 	var queue1 = Queue.FromArray([]int{1, 2, 3})

--- a/v3/queue_test.go
+++ b/v3/queue_test.go
@@ -17,6 +17,13 @@ import (
 	tes "testing"
 )
 
+func TestQueueConstructors(t *tes.T) {
+	var Queue = col.Queue[int]()
+	var queue1 = Queue.FromArray([]int{1, 2, 3})
+	var queue2 = Queue.FromSequence(queue1)
+	ass.Equal(t, queue1.AsArray(), queue2.AsArray())
+}
+
 func TestQueueWithConcurrency(t *tes.T) {
 	// Create a wait group for synchronization.
 	var wg = new(syn.WaitGroup)

--- a/v3/set.go
+++ b/v3/set.go
@@ -55,6 +55,14 @@ func (c *setClass_[V]) Empty() SetLike[V] {
 	return set
 }
 
+// This public class constructor creates a new Set from the specified Go array
+// of values.
+func (c *setClass_[V]) FromArray(values []V) SetLike[V] {
+	var array = Array[V]().FromArray(values)
+	var set = c.FromSequence(array)
+	return set
+}
+
 // This public class constructor creates a new Set from the specified sequence
 // of values.  The Set uses the default ranking function to order its values.
 func (c *setClass_[V]) FromSequence(values Sequential[V]) SetLike[V] {

--- a/v3/set.go
+++ b/v3/set.go
@@ -85,6 +85,22 @@ func (c *setClass_[V]) FromSequenceWithRanker(
 	return set
 }
 
+// This public class constructor creates a new Set from the specified string
+// containing the CDCN definition for the Set.
+func (c *setClass_[V]) FromString(source string) SetLike[V] {
+	// First we parse it as a collection of any type value.
+	var collection = Parser().ParseCollection([]byte(source)).(Sequential[Value])
+
+	// Then we convert it to a Set of type V.
+	var set = c.Empty()
+	var iterator = collection.GetIterator()
+	for iterator.HasNext() {
+		var value = iterator.GetNext().(V)
+		set.AddValue(value)
+	}
+	return set
+}
+
 // This public class constructor creates a new empty Set.
 // The Set uses the specified ranking function to order its values.
 func (c *setClass_[V]) WithRanker(ranker RankingFunction) SetLike[V] {
@@ -153,13 +169,13 @@ type set_[V Value] struct {
 
 // Accessible Interface
 
-// This public class method retrieves from this array the value that is
+// This public class method retrieves from this Set the value that is
 // associated with the specified index.
 func (v *set_[V]) GetValue(index int) V {
 	return v.values.GetValue(index)
 }
 
-// This public class method retrieves from this array all values from the first
+// This public class method retrieves from this Set all values from the first
 // index through the last index (inclusive).
 func (v *set_[V]) GetValues(first int, last int) Sequential[V] {
 	return v.values.GetValues(first, last)
@@ -273,8 +289,8 @@ func (v *set_[V]) GetIndex(value V) int {
 
 // Sequential Interface
 
-// This public class method returns all the values in this array. The values
-// retrieved are in the same order as they are in the array.
+// This public class method returns all the values in this Set. The values
+// retrieved are in the same order as they are in the Set.
 func (v *set_[V]) AsArray() []V {
 	return v.values.AsArray()
 }
@@ -287,12 +303,12 @@ func (v *set_[V]) GetIterator() Ratcheted[V] {
 }
 
 // This public class method returns the number of values contained in this
-// array.
+// Set.
 func (v *set_[V]) GetSize() int {
 	return v.values.GetSize()
 }
 
-// This public class method determines whether or not this array is empty.
+// This public class method determines whether or not this Set is empty.
 func (v *set_[V]) IsEmpty() bool {
 	return v.values.IsEmpty()
 }

--- a/v3/set_test.go
+++ b/v3/set_test.go
@@ -16,6 +16,11 @@ import (
 	tes "testing"
 )
 
+func TestSetConstructor(t *tes.T) {
+	var _ = col.Set[int64]().FromString("[ ](Set)\n")
+	var _ = col.Set[int64]().FromString("[1, 2, 3](Set)\n")
+}
+
 func TestSetConstructors(t *tes.T) {
 	var Set = col.Set[int]()
 	var set1 = Set.FromArray([]int{1, 2, 3})

--- a/v3/set_test.go
+++ b/v3/set_test.go
@@ -16,6 +16,13 @@ import (
 	tes "testing"
 )
 
+func TestSetConstructors(t *tes.T) {
+	var Set = col.Set[int]()
+	var set1 = Set.FromArray([]int{1, 2, 3})
+	var set2 = Set.FromSequence(set1)
+	ass.Equal(t, set1.AsArray(), set2.AsArray())
+}
+
 func TestSetsWithStrings(t *tes.T) {
 	var Collator = col.Collator()
 	var Array = col.Array[string]()

--- a/v3/stack.go
+++ b/v3/stack.go
@@ -84,6 +84,22 @@ func (c *stackClass_[V]) FromSequence(values Sequential[V]) StackLike[V] {
 	return stack
 }
 
+// This public class constructor creates a new Stack from the specified string
+// containing the CDCN definition for the Stack.
+func (c *stackClass_[V]) FromString(source string) StackLike[V] {
+	// First we parse it as a collection of any type value.
+	var collection = Parser().ParseCollection([]byte(source)).(Sequential[Value])
+
+	// Then we convert it to a Stack of type V.
+	var stack = c.Empty()
+	var iterator = collection.GetIterator()
+	for iterator.HasNext() {
+		var value = iterator.GetNext().(V)
+		stack.AddValue(value)
+	}
+	return stack
+}
+
 // This public class constructor creates a new empty Stack with the specified
 // capacity.
 func (c *stackClass_[V]) WithCapacity(capacity int) StackLike[V] {

--- a/v3/stack.go
+++ b/v3/stack.go
@@ -63,6 +63,14 @@ func (c *stackClass_[V]) Empty() StackLike[V] {
 	return stack
 }
 
+// This public class constructor creates a new Stack from the specified Go array
+// of values.
+func (c *stackClass_[V]) FromArray(values []V) StackLike[V] {
+	var array = Array[V]().FromArray(values)
+	var stack = c.FromSequence(array)
+	return stack
+}
+
 // This public class constructor creates a new Stack from the specified
 // sequence of values. The Stack uses the default capacity.
 func (c *stackClass_[V]) FromSequence(values Sequential[V]) StackLike[V] {

--- a/v3/stack_test.go
+++ b/v3/stack_test.go
@@ -16,6 +16,13 @@ import (
 	tes "testing"
 )
 
+func TestStackConstructors(t *tes.T) {
+	var Stack = col.Stack[int]()
+	var stack1 = Stack.FromArray([]int{1, 2, 3})
+	var stack2 = Stack.FromSequence(stack1)
+	ass.Equal(t, stack1.AsArray(), stack2.AsArray())
+}
+
 func TestStackWithSmallCapacity(t *tes.T) {
 	var Stack = col.Stack[int]()
 	var stack = Stack.WithCapacity(1)

--- a/v3/stack_test.go
+++ b/v3/stack_test.go
@@ -16,6 +16,11 @@ import (
 	tes "testing"
 )
 
+func TestStackConstructor(t *tes.T) {
+	var _ = col.Stack[int64]().FromString("[ ](Stack)\n")
+	var _ = col.Stack[int64]().FromString("[1, 2, 3](Stack)\n")
+}
+
 func TestStackConstructors(t *tes.T) {
 	var Stack = col.Stack[int]()
 	var stack1 = Stack.FromArray([]int{1, 2, 3})


### PR DESCRIPTION
This pull request addresses issue #: 

A summary of the changes included in this pull request:
 1. Added a `Map[Key, Value]().Empty()` constructor.
 1. Added `.FromString(string)` constructors to all collection classes.
 1. Added `.FromArray(array)` constructors to each collection class that did not already have one.

To be reviewed by: @derknorton
