### PR TITLE
Added Catalog.FromMap(map) Function

### DIFF
--- a/v3/catalog.go
+++ b/v3/catalog.go
@@ -18,7 +18,9 @@ import (
 
 // This private type defines the namespace structure associated with the
 // constants, constructors and functions for the Catalog class namespace.
-type catalogClass_[K Key, V Value] struct {
+// NOTE: the Go language requires the key type here support the "comparable"
+// interface so we must narrow it down from "any".
+type catalogClass_[K comparable, V Value] struct {
 	// This class defines no constants.
 }
 
@@ -28,7 +30,9 @@ var catalogClassSingletons = map[string]any{}
 
 // This public function returns the singleton reference to a type specific
 // Catalog class namespace.  It also initializes any class constants as needed.
-func Catalog[K Key, V Value]() *catalogClass_[K, V] {
+// NOTE: the Go language requires the key type here support the "comparable"
+// interface so we must narrow it down from "any".
+func Catalog[K comparable, V Value]() *catalogClass_[K, V] {
 	var class *catalogClass_[K, V]
 	var key = fmt.Sprintf("%T", class) // The name of the bound class type.
 	var value = catalogClassSingletons[key]
@@ -63,6 +67,18 @@ func (c *catalogClass_[K, V]) FromArray(
 ) CatalogLike[K, V] {
 	var array = Array[Binding[K, V]]().FromArray(associations)
 	var catalog = c.FromSequence(array)
+	return catalog
+}
+
+// This public class constructor creates a new Catalog from the specified
+// Go map of associations.
+func (c *catalogClass_[K, V]) FromMap(
+	associations map[K]V,
+) CatalogLike[K, V] {
+	var catalog = c.Empty()
+	for key, value := range associations {
+		catalog.SetValue(key, value)
+	}
 	return catalog
 }
 

--- a/v3/catalog_test.go
+++ b/v3/catalog_test.go
@@ -16,9 +16,17 @@ import (
 	tes "testing"
 )
 
-func TestCatalogConstructor(t *tes.T) {
-	var _ = col.Catalog[rune, int64]().FromString("[:](Catalog)\n")
-	var _ = col.Catalog[rune, int64]().FromString("['a': 1, 'b': 2, 'c': 3](Catalog)\n")
+func TestCatalogConstructors(t *tes.T) {
+	var Catalog = col.Catalog[rune, int64]()
+	var _ = Catalog.FromArray([]col.Binding[rune, int64]{})
+	var _ = Catalog.FromString("[:](Catalog)\n")
+	var _ = Catalog.FromString("['a': 1, 'b': 2, 'c': 3](Catalog)\n")
+	var _ = Catalog.FromMap(map[rune]int64{})
+	var _ = Catalog.FromMap(map[rune]int64{
+		'a': 1,
+		'b': 2,
+		'c': 3,
+	})
 }
 
 func TestCatalogsWithStringsAndIntegers(t *tes.T) {

--- a/v3/map_test.go
+++ b/v3/map_test.go
@@ -16,9 +16,17 @@ import (
 	tes "testing"
 )
 
-func TestMapConstructor(t *tes.T) {
-	var _ = col.Map[rune, int64]().FromString("[:](Map)\n")
-	var _ = col.Map[rune, int64]().FromString("['a': 1, 'b': 2, 'c': 3](Map)\n")
+func TestMapConstructors(t *tes.T) {
+	var Map = col.Map[rune, int64]()
+	var _ = Map.FromArray([]col.Binding[rune, int64]{})
+	var _ = Map.FromString("[:](Map)\n")
+	var _ = Map.FromString("['a': 1, 'b': 2, 'c': 3](Map)\n")
+	var _ = Map.FromMap(map[rune]int64{})
+	var _ = Map.FromMap(map[rune]int64{
+		'a': 1,
+		'b': 2,
+		'c': 3,
+	})
 }
 
 func TestEmptyMaps(t *tes.T) {

--- a/v3/parser.go
+++ b/v3/parser.go
@@ -174,7 +174,7 @@ func (v *parser_) nextToken() TokenLike {
 func (v *parser_) parseAssociation() (AssociationLike[Key, Value], TokenLike, bool) {
 	var ok bool
 	var token TokenLike
-	var key Primitive
+	var key Key
 	var value Value
 	var association AssociationLike[Key, Value]
 	key, token, ok = v.parsePrimitive()


### PR DESCRIPTION
This pull request addresses issue #41: 

A summary of the changes included in this pull request:
 1. Added a `FromMap(associations map[K]V) CatalogLike[K, V]` class function to the `Catalog[Key, Value]` class namespace.
 1. Added unit tests to confirm it works.

To be reviewed by: @derknorton
