### PR TITLE
Implemented and tested issue #49.

### DIFF
--- a/v3/CHANGES.md
+++ b/v3/CHANGES.md
@@ -31,11 +31,11 @@ number of the package must be incremented.
 
 In doing this, the following class types are no longer part of the public
 interface for the package:
- * Token
- * Scanner
- * Parser
- * Collator
- * Sorter[Value]
+ * `Formatter`
+ * `Parser`
+ * `Scanner`
+ * `Sorter[Value]`
+ * `Token`
 
 These classes are still available from the package but any dependencies on them
 are not guaranteed to be stable.
@@ -58,17 +58,16 @@ for more details on class namespaces.
 These two classes which were type extensions before are now fully encapsulated
 classes with their own namespaces just like the rest of the collection classes.
 
-### `Stringent` Interface
-This interface was added to codify the methods that must be supported by all
-lexical parsing agents.
-
-### `Standardized` Interface
-This interface was added to codify the methods that must be supported by all
-canonical formatting agents.
-
 ### `Malleable[V]` Interface Refactored and Renamed
 The `Malleable[V]` interface has been renamed to `Extendable[V]` and the `AddValue()`
 and `AddValues()` methods renamed to `AppendValue()` and `AppendValues()` for
 clarity since they only append values to the end of a sequence.
+
+### Interfaces Removed
+The following interfaces have been removed from the package:
+ * `Binding[K, V]`
+ * `Ratcheted[V]`
+ * `FIFO[V]`
+ * `LIFO[V]`
 
 <H5 align="center"> Copyright © 2009 - 2024  Crater Dog Technologies™. All rights reserved. </H5>

--- a/v3/array.go
+++ b/v3/array.go
@@ -119,7 +119,7 @@ func (v array_[V]) AsArray() []V {
 	return array
 }
 
-func (v array_[V]) GetIterator() Ratcheted[V] {
+func (v array_[V]) GetIterator() IteratorLike[V] {
 	var iterator = IteratorClass[V]().FromSequence(v)
 	return iterator
 }

--- a/v3/association.go
+++ b/v3/association.go
@@ -62,7 +62,7 @@ type association_[K Key, V Value] struct {
 	value V
 }
 
-// Binding Interface
+// Public Interface
 
 func (v *association_[K, V]) GetKey() K {
 	return v.key

--- a/v3/catalog.go
+++ b/v3/catalog.go
@@ -51,16 +51,16 @@ func CatalogClass[K comparable, V Value]() CatalogClassLike[K, V] {
 // Public Class Constructors
 
 func (c *catalogClass_[K, V]) Empty() CatalogLike[K, V] {
-	var keys = map[K]Binding[K, V]{}
-	var associations = ListClass[Binding[K, V]]().Empty()
+	var keys = map[K]AssociationLike[K, V]{}
+	var associations = ListClass[AssociationLike[K, V]]().Empty()
 	var catalog = &catalog_[K, V]{associations, keys}
 	return catalog
 }
 
 func (c *catalogClass_[K, V]) FromArray(
-	associations []Binding[K, V],
+	associations []AssociationLike[K, V],
 ) CatalogLike[K, V] {
-	var array = ArrayClass[Binding[K, V]]().FromArray(associations)
+	var array = ArrayClass[AssociationLike[K, V]]().FromArray(associations)
 	var catalog = c.FromSequence(array)
 	return catalog
 }
@@ -76,7 +76,7 @@ func (c *catalogClass_[K, V]) FromMap(
 }
 
 func (c *catalogClass_[K, V]) FromSequence(
-	associations Sequential[Binding[K, V]],
+	associations Sequential[AssociationLike[K, V]],
 ) CatalogLike[K, V] {
 	var catalog = c.Empty()
 	var iterator = associations.GetIterator()
@@ -92,9 +92,9 @@ func (c *catalogClass_[K, V]) FromSequence(
 func (c *catalogClass_[K, V]) FromString(associations string) CatalogLike[K, V] {
 	// First we parse it as a collection of any type value.
 	var cdcn = CDCNClass().Default()
-	var collection = cdcn.ParseCollection(associations).(Sequential[Binding[Key, Value]])
+	var collection = cdcn.ParseCollection(associations).(Sequential[AssociationLike[Key, Value]])
 
-	// Then we convert it to a catalog of type Binding[K, V].
+	// Then we convert it to a catalog of type AssociationLike[K, V].
 	var catalog = c.Empty()
 	var iterator = collection.GetIterator()
 	for iterator.HasNext() {
@@ -150,8 +150,8 @@ func (c *catalogClass_[K, V]) Merge(
 // Private Class Type Definition
 
 type catalog_[K comparable, V Value] struct {
-	associations ListLike[Binding[K, V]]
-	keys         map[K]Binding[K, V]
+	associations ListLike[AssociationLike[K, V]]
+	keys         map[K]AssociationLike[K, V]
 }
 
 // Associative Interface
@@ -187,7 +187,7 @@ func (v *catalog_[K, V]) GetValues(keys Sequential[K]) Sequential[V] {
 }
 
 func (v *catalog_[K, V]) RemoveAll() {
-	v.keys = map[K]Binding[K, V]{}
+	v.keys = map[K]AssociationLike[K, V]{}
 	v.associations.RemoveAll()
 }
 
@@ -228,11 +228,11 @@ func (v *catalog_[K, V]) SetValue(key K, value V) {
 
 // Sequential Interface
 
-func (v *catalog_[K, V]) AsArray() []Binding[K, V] {
+func (v *catalog_[K, V]) AsArray() []AssociationLike[K, V] {
 	return v.associations.AsArray()
 }
 
-func (v *catalog_[K, V]) GetIterator() Ratcheted[Binding[K, V]] {
+func (v *catalog_[K, V]) GetIterator() IteratorLike[AssociationLike[K, V]] {
 	return v.associations.GetIterator()
 }
 

--- a/v3/catalog_test.go
+++ b/v3/catalog_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestCatalogConstructors(t *tes.T) {
 	var Catalog = col.CatalogClass[rune, int64]()
-	var _ = Catalog.FromArray([]col.Binding[rune, int64]{})
+	var _ = Catalog.FromArray([]col.AssociationLike[rune, int64]{})
 	var _ = Catalog.FromString("[:](Catalog)")
 	var _ = Catalog.FromString("['a': 1, 'b': 2, 'c': 3](Catalog)")
 	var _ = Catalog.FromMap(map[rune]int64{})
@@ -41,7 +41,7 @@ func TestCatalogsWithStringsAndIntegers(t *tes.T) {
 	ass.True(t, catalog.IsEmpty())
 	ass.Equal(t, 0, catalog.GetSize())
 	ass.Equal(t, []string{}, catalog.GetKeys().AsArray())
-	ass.Equal(t, []col.Binding[string, int]{}, catalog.AsArray())
+	ass.Equal(t, []col.AssociationLike[string, int]{}, catalog.AsArray())
 	var iterator = catalog.GetIterator()
 	ass.False(t, iterator.HasNext())
 	ass.False(t, iterator.HasPrevious())
@@ -134,7 +134,7 @@ func TestCatalogsWithExtract(t *tes.T) {
 	catalog3.SetValue(association1.GetKey(), association1.GetValue())
 	catalog3.SetValue(association3.GetKey(), association3.GetValue())
 	ass.True(t, collator.CompareValues(catalog2, catalog3))
-	var catalog4 = Catalog.FromArray([]col.Binding[string, int]{
+	var catalog4 = Catalog.FromArray([]col.AssociationLike[string, int]{
 		association1,
 		association2,
 		association3,

--- a/v3/cdcn.go
+++ b/v3/cdcn.go
@@ -63,14 +63,12 @@ type cdcn_ struct {
 	parser    *parser_
 }
 
-// Standardized Interface
+// Public Interface
 
 func (v *cdcn_) FormatCollection(collection Collection) string {
 	return v.formatter.FormatCollection(collection)
 }
 
-// Stringent Interface
-
-func (v *cdcn_) ParseCollection(source string) Collection {
-	return v.parser.ParseCollection(source)
+func (v *cdcn_) ParseCollection(collection string) Collection {
+	return v.parser.ParseCollection(collection)
 }

--- a/v3/collator.go
+++ b/v3/collator.go
@@ -34,7 +34,7 @@ var collatorClass = &collatorClass_{
 
 // Public Class Namespace Access
 
-func CollatorClass() *collatorClass_ {
+func CollatorClass() CollatorClassLike {
 	return collatorClass
 }
 
@@ -46,14 +46,14 @@ func (c *collatorClass_) GetDefaultDepth() int {
 
 // Public Class Constructors
 
-func (c *collatorClass_) Default() *collator_ {
+func (c *collatorClass_) Default() CollatorLike {
 	var collator = &collator_{
 		maximum: c.defaultDepth,
 	}
 	return collator
 }
 
-func (c *collatorClass_) WithDepth(depth int) *collator_ {
+func (c *collatorClass_) WithDepth(depth int) CollatorLike {
 	if depth < 0 || depth > c.defaultDepth {
 		depth = c.defaultDepth
 	}
@@ -72,7 +72,7 @@ type collator_ struct {
 	maximum int
 }
 
-// Discerning Interface
+// Public Interface
 
 func (v *collator_) CompareValues(first Value, second Value) bool {
 	return v.compareValues(ref.ValueOf(first), ref.ValueOf(second))

--- a/v3/formatter.go
+++ b/v3/formatter.go
@@ -57,7 +57,7 @@ type formatter_ struct {
 	result      sts.Builder
 }
 
-// Standardized Interface
+// Public Interface
 
 func (v *formatter_) FormatCollection(collection Collection) string {
 	var reflected = ref.ValueOf(collection)

--- a/v3/iterator.go
+++ b/v3/iterator.go
@@ -68,7 +68,7 @@ type iterator_[V Value] struct {
 	values []V // The Go array of values is immutable.
 }
 
-// Ratcheted Interface
+// Public Interface
 
 func (v *iterator_[V]) GetNext() V {
 	var result V

--- a/v3/list.go
+++ b/v3/list.go
@@ -49,9 +49,10 @@ func ListClass[V Value]() ListClassLike[V] {
 // Public Class Constructors
 
 func (c *listClass_[V]) Empty() ListLike[V] {
-	var collator = CollatorClass().Default()
-	var comparer = collator.CompareValues
-	var list = c.WithComparer(comparer)
+	var values = ArrayClass[V]().WithSize(0)
+	var list = &list_[V]{
+		values: values,
+	}
 	return list
 }
 
@@ -86,15 +87,6 @@ func (c *listClass_[V]) FromString(values string) ListLike[V] {
 	return list
 }
 
-func (c *listClass_[V]) WithComparer(comparer ComparingFunction) ListLike[V] {
-	var values = ArrayClass[V]().WithSize(0)
-	var list = &list_[V]{
-		compare: comparer,
-		values:  values,
-	}
-	return list
-}
-
 // Public Class Functions
 
 // This public class function returns the concatenation of the two specified
@@ -111,8 +103,7 @@ func (c *listClass_[V]) Concatenate(first, second ListLike[V]) ListLike[V] {
 // Private Class Type Definition
 
 type list_[V Value] struct {
-	compare ComparingFunction
-	values  ArrayLike[V]
+	values ArrayLike[V]
 }
 
 // Accessible Interface
@@ -326,13 +317,10 @@ func (v *list_[V]) ContainsValue(value V) bool {
 	return v.GetIndex(value) > 0
 }
 
-func (v *list_[V]) GetComparer() ComparingFunction {
-	return v.compare
-}
-
 func (v *list_[V]) GetIndex(value V) int {
+	var compare = CollatorClass().Default().CompareValues
 	for index, candidate := range v.AsArray() {
-		if v.compare(candidate, value) {
+		if compare(candidate, value) {
 			// Found the value.
 			return index + 1 // Convert to an ORDINAL based index.
 		}
@@ -347,7 +335,7 @@ func (v *list_[V]) AsArray() []V {
 	return v.values.AsArray()
 }
 
-func (v *list_[V]) GetIterator() Ratcheted[V] {
+func (v *list_[V]) GetIterator() IteratorLike[V] {
 	return v.values.GetIterator()
 }
 

--- a/v3/list_test.go
+++ b/v3/list_test.go
@@ -161,25 +161,6 @@ func TestListsWithTildes(t *tes.T) {
 	ass.Equal(t, 3, int(list.GetValue(3)))  // [1,2,3,4,5,9]
 }
 
-func BadCompare(first col.Value, second col.Value) bool {
-	panic("KaPow!")
-}
-
-func TestListsWithComparer(t *tes.T) {
-	var list = col.ListClass[int]().WithComparer(BadCompare)
-	list.AppendValue(1)
-	list.AppendValue(2)
-	list.AppendValue(3)
-	defer func() {
-		if e := recover(); e != nil {
-			ass.Equal(t, "KaPow!", e)
-		} else {
-			ass.Fail(t, "Test should result in recovered panic.")
-		}
-	}()
-	list.GetIndex(2)
-}
-
 func TestListsWithConcatenate(t *tes.T) {
 	var List = col.ListClass[int]()
 	var collator = col.CollatorClass().Default()

--- a/v3/map.go
+++ b/v3/map.go
@@ -54,7 +54,7 @@ func (c *mapClass_[K, V]) Empty() MapLike[K, V] {
 	return map_[K, V](map[K]V{})
 }
 
-func (c *mapClass_[K, V]) FromArray(associations []Binding[K, V]) MapLike[K, V] {
+func (c *mapClass_[K, V]) FromArray(associations []AssociationLike[K, V]) MapLike[K, V] {
 	var size = len(associations)
 	var duplicate = make(map[K]V, size)
 	for _, association := range associations {
@@ -75,7 +75,7 @@ func (c *mapClass_[K, V]) FromMap(associations map[K]V) MapLike[K, V] {
 }
 
 func (c *mapClass_[K, V]) FromSequence(
-	associations Sequential[Binding[K, V]],
+	associations Sequential[AssociationLike[K, V]],
 ) MapLike[K, V] {
 	var size = associations.GetSize()
 	var iterator = associations.GetIterator()
@@ -92,9 +92,9 @@ func (c *mapClass_[K, V]) FromSequence(
 func (c *mapClass_[K, V]) FromString(associations string) MapLike[K, V] {
 	// First we parse it as a collection of any type value.
 	var cdcn = CDCNClass().Default()
-	var collection = cdcn.ParseCollection(associations).(Sequential[Binding[Key, Value]])
+	var collection = cdcn.ParseCollection(associations).(Sequential[AssociationLike[Key, Value]])
 
-	// Then we convert it to a Map of type Binding[K, V].
+	// Then we convert it to a Map of type AssociationLike[K, V].
 	var map_ = c.Empty()
 	var iterator = collection.GetIterator()
 	for iterator.HasNext() {
@@ -172,9 +172,9 @@ func (v map_[K, V]) SetValue(key K, value V) {
 
 // Sequential Interface
 
-func (v map_[K, V]) AsArray() []Binding[K, V] {
+func (v map_[K, V]) AsArray() []AssociationLike[K, V] {
 	var size = len(v)
-	var result = make([]Binding[K, V], size)
+	var result = make([]AssociationLike[K, V], size)
 	var index = 0
 	for key, value := range v {
 		var association = AssociationClass[K, V]().FromPair(key, value)
@@ -184,8 +184,8 @@ func (v map_[K, V]) AsArray() []Binding[K, V] {
 	return result
 }
 
-func (v map_[K, V]) GetIterator() Ratcheted[Binding[K, V]] {
-	var array = ArrayClass[Binding[K, V]]().FromArray(v.AsArray())
+func (v map_[K, V]) GetIterator() IteratorLike[AssociationLike[K, V]] {
+	var array = ArrayClass[AssociationLike[K, V]]().FromArray(v.AsArray())
 	var iterator = array.GetIterator()
 	return iterator
 }

--- a/v3/map_test.go
+++ b/v3/map_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestMapConstructors(t *tes.T) {
 	var Map = col.MapClass[rune, int64]()
-	var _ = Map.FromArray([]col.Binding[rune, int64]{})
+	var _ = Map.FromArray([]col.AssociationLike[rune, int64]{})
 	var _ = Map.FromMap(map[rune]int64{})
 	var sequence = Map.FromMap(map[rune]int64{'a': 1, 'b': 2, 'c': 3})
 	var _ = Map.FromSequence(sequence)
@@ -31,7 +31,7 @@ func TestEmptyMaps(t *tes.T) {
 	ass.True(t, m.IsEmpty())
 	ass.Equal(t, 0, m.GetSize())
 	ass.Equal(t, []string{}, m.GetKeys().AsArray())
-	ass.Equal(t, []col.Binding[string, int]{}, m.AsArray())
+	ass.Equal(t, []col.AssociationLike[string, int]{}, m.AsArray())
 	var iterator = m.GetIterator()
 	ass.False(t, iterator.HasNext())
 	ass.False(t, iterator.HasPrevious())
@@ -46,7 +46,7 @@ func TestMapsWithStringsAndIntegers(t *tes.T) {
 	var association2 = Association.FromPair("bar", 2)
 	var association3 = Association.FromPair("baz", 3)
 	var Map = col.MapClass[string, int]()
-	var m = Map.FromArray([]col.Binding[string, int]{
+	var m = Map.FromArray([]col.AssociationLike[string, int]{
 		association1,
 		association2,
 		association3,

--- a/v3/parser.go
+++ b/v3/parser.go
@@ -58,7 +58,7 @@ type parser_ struct {
 	tokens chan *token_       // A queue of unread tokens coming from the scanner.
 }
 
-// Stringent Interface
+// Public Interface
 
 func (v *parser_) ParseCollection(source string) Collection {
 	// Start a scanner running in a separate Go routine.
@@ -186,10 +186,10 @@ func (v *parser_) parseAssociation() (AssociationLike[Key, Value], *token_, bool
 // This private class method attempts to parse a sequence of associations. It
 // returns the sequence of associations and whether or not the sequence of
 // associations was successfully parsed.
-func (v *parser_) parseAssociations() (Sequential[Binding[Key, Value]], *token_, bool) {
+func (v *parser_) parseAssociations() (Sequential[AssociationLike[Key, Value]], *token_, bool) {
 	var ok bool
 	var token *token_
-	var associations Sequential[Binding[Key, Value]]
+	var associations Sequential[AssociationLike[Key, Value]]
 	_, token, ok = v.parseDelimiter(":")
 	if ok {
 		// The associations is empty.
@@ -291,7 +291,7 @@ func (v *parser_) parseCollection() (Collection, *token_, bool) {
 			var message = fmt.Sprintf("Found an unknown collection type: %q", context)
 			panic(message)
 		}
-	case Sequential[Binding[Key, Value]]:
+	case Sequential[AssociationLike[Key, Value]]:
 		switch context {
 		case "map":
 			var map_ = map[Key]Value{}
@@ -413,7 +413,7 @@ func (v *parser_) parseFloat() (float64, *token_, bool) {
 // This private class method attempts to parse a sequence containing inline
 // associations. It returns a sequence of associations and whether or not the
 // sequence of associations was successfully parsed.
-func (v *parser_) parseInlineAssociations() (Sequential[Binding[Key, Value]], *token_, bool) {
+func (v *parser_) parseInlineAssociations() (Sequential[AssociationLike[Key, Value]], *token_, bool) {
 	var ok bool
 	var token *token_
 	var association AssociationLike[Key, Value]
@@ -497,7 +497,7 @@ func (v *parser_) parseInteger() (int64, *token_, bool) {
 // This private class method attempts to parse a sequence containing multi-line
 // associations.  It returns the sequence of associations and whether or not the
 // sequence of associations was successfully parsed.
-func (v *parser_) parseMultilineAssociations() (Sequential[Binding[Key, Value]], *token_, bool) {
+func (v *parser_) parseMultilineAssociations() (Sequential[AssociationLike[Key, Value]], *token_, bool) {
 	var ok bool
 	var token *token_
 	var association AssociationLike[Key, Value]


### PR DESCRIPTION
This pull request addresses issue #49: 

A summary of the changes included in this pull request:
 1. The attempt to change the backing store of the `Stack[V]` (and `Queue[V]`) classes was not successful for various reasons.  It turns out that the implementation of the `List[V]` class is pretty well optimized and efficiently uses its underlying array, so the replacement of the backing `List[V]` with an array doesn't really buy us much.
 2. I did revisit the constructors for both the `Stack[V]` and `Queue[V]` classes and optimized them with respect to the backing `List[V]` and they are now very efficient.

To be reviewed by: @derknorton
